### PR TITLE
docs: update Eloquent documentation link

### DIFF
--- a/doc/create-model.md
+++ b/doc/create-model.md
@@ -34,7 +34,7 @@ class MyModel extends AbstractModel
 
 Once a model is defined, you are ready to start retrieving and creating records in your table. Note that you will need to place `updated_at` and `created_at` columns on your table by default. If you do not wish to have these columns automatically maintained, set the `$timestamps` property on your model to false.
 
-> 📘 If you want to know more about creating a model you can look the [Eloquent documentation](https://laravel.com/docs/5.0/eloquent#basic-usage).
+> 📘 If you want to know more about creating a model you can look the [Eloquent documentation](https://laravel.com/docs/10.x/eloquent#eloquent-model-conventions).
 
 ### Add meta relation
 


### PR DESCRIPTION
I noticed that the link to the documentation leads to an old version of Eloquent. This library uses version 10.x.
https://github.com/dimitriBouteille/wp-orm/blob/2bca694bb5f73706fcda4ef470efd0cbd786ee12/composer.json#L25