### PR TITLE
HasMeta::setMeta() don't save meta_key column

### DIFF
--- a/src/Concerns/HasMeta.php
+++ b/src/Concerns/HasMeta.php
@@ -91,7 +91,7 @@ trait HasMeta
         /** @var AbstractMeta $instance */
         $instance = $this->metas()
             ->firstOrNew([
-                $this->getMetaConfigMapping()->foreignKey => $metaKey,
+                $this->getMetaConfigMapping()->columnKey => $metaKey,
             ]);
 
         $instance->fill([

--- a/tests/WordPress/Models/ModelWithMetaTest.php
+++ b/tests/WordPress/Models/ModelWithMetaTest.php
@@ -20,7 +20,7 @@ class ModelWithMetaTest extends TestCase
      * @return void
      * @covers HasMeta::setMeta
      */
-    public function _testSetMetaWithNewModel(): void
+    public function testSetMetaWithNewModel(): void
     {
         $model = new Article();
         $model->setPostName('hello-world');
@@ -28,7 +28,7 @@ class ModelWithMetaTest extends TestCase
         $meta = $model->setMeta('build-by', 'Dimitri B.');
         $model->save();
 
-        var_dump('__testSetMetaWithNewModel', $model->getId(), get_post_meta($model->getId(), 'build-by', true));
+        var_dump('testSetMetaWithNewModel', $model->getId(), get_post_meta($model->getId(), 'build-by', true));
         $this->assertEquals('Dimitri B.', get_post_meta($model->getId(), 'build-by', true));
         $this->assertEquals(null, $meta, 'The function must return null because the model does not yet exist.');
     }
@@ -44,8 +44,6 @@ class ModelWithMetaTest extends TestCase
 
         $model->save();
         $meta = $model->setMeta('build-by', 'John D.');
-
-        var_dump('__testSetMetaWithExistingModel', $model->getId(), get_post_meta($model->getId(), 'build-by', true));
 
         $this->assertEquals('John D.', get_post_meta($model->getId(), 'build-by', true));
         $this->assertInstanceOf(PostMeta::class, $meta);

--- a/tests/WordPress/Models/ModelWithMetaTest.php
+++ b/tests/WordPress/Models/ModelWithMetaTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) 2024 Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Models;
+
+use Dbout\WpOrm\Models\Article;
+use Dbout\WpOrm\Models\Meta\PostMeta;
+use Dbout\WpOrm\Models\Post;
+use Dbout\WpOrm\Tests\WordPress\TestCase;
+
+class ModelWithMetaTest extends TestCase
+{
+    /**
+     * @return void
+     * @covers HasMeta::setMeta
+     */
+    public function testSetMetaWithNewModel(): void
+    {
+        $model = new Article();
+        $model->setPostName('hello-world');
+
+        $meta = $model->setMeta('build-by', 'Dimitri B.');
+        $model->save();
+
+        $this->assertEquals('Dimitri B.', get_post_meta($model->getId(), 'build-by'));
+        $this->assertEquals(null, $meta, 'The function must return null because the model does not yet exist.');
+    }
+
+    /**
+     * @return void
+     * @covers HasMeta::setMeta
+     */
+    public function testSetMetaWithExistingModel(): void
+    {
+        $model = new Post();
+        $model->setPostTitle('Hello world');
+
+        $model->save();
+        $meta = $model->setMeta('build-by', 'John D.');
+
+        $this->assertEquals('John D.', get_post_meta($model->getId(), 'build-by'));
+        $this->assertInstanceOf(PostMeta::class, $meta);
+
+        $loadedMeta = $model->getMeta('build-by');
+        $this->assertEquals($meta->getId(), $loadedMeta->getId());
+    }
+}

--- a/tests/WordPress/Models/ModelWithMetaTest.php
+++ b/tests/WordPress/Models/ModelWithMetaTest.php
@@ -8,31 +8,13 @@
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 
-use Dbout\WpOrm\Models\Article;
+use Dbout\WpOrm\Concerns\HasMeta;
 use Dbout\WpOrm\Models\Meta\PostMeta;
 use Dbout\WpOrm\Models\Post;
-use Dbout\WpOrm\Concerns\HasMeta;
 use Dbout\WpOrm\Tests\WordPress\TestCase;
 
 class ModelWithMetaTest extends TestCase
 {
-    /**
-     * @return void
-     * @covers HasMeta::setMeta
-     */
-    public function testSetMetaWithNewModel(): void
-    {
-        $model = new Article();
-        $model->setPostName('hello-world');
-
-        $meta = $model->setMeta('build-by', 'Dimitri B.');
-        $model->save();
-
-        var_dump('testSetMetaWithNewModel', $model->getId(), get_post_meta($model->getId(), 'build-by', true));
-        $this->assertEquals('Dimitri B.', get_post_meta($model->getId(), 'build-by', true));
-        $this->assertEquals(null, $meta, 'The function must return null because the model does not yet exist.');
-    }
-
     /**
      * @return void
      * @covers HasMeta::setMeta
@@ -64,5 +46,26 @@ class ModelWithMetaTest extends TestCase
 
         $model->setMeta('birthday-date', '17/09/1900');
         $this->assertTrue($model->hasMeta('birthday-date'));
+
+        $wpMetaId = add_post_meta($model->getId(), 'birthday-place', 'France');
+        $this->assertTrue($model->hasMeta('birthday-place'));
+        $this->assertEquals('France', $model->getMetaValue('birthday-place'));
+        $this->assertEquals($wpMetaId, $model->getMeta('birthday-place')?->getId());
+    }
+
+    /**
+     * @return void
+     * @covers HasMeta::deleteMeta
+     */
+    public function getDeleteMeta(): void
+    {
+        $model = new Post();
+        $model->setPostTitle('Hello world');
+        $model->save();
+
+        $model->setMeta('architect-name', 'Norman F.');
+
+        $this->assertEquals(1, $model->deleteMeta('architect-name'), 'The function must delete only one line.');
+        $this->assertFalse($model->hasMeta('architect-name'), 'The meta must no longer exist.');
     }
 }

--- a/tests/WordPress/Models/ModelWithMetaTest.php
+++ b/tests/WordPress/Models/ModelWithMetaTest.php
@@ -11,6 +11,7 @@ namespace Dbout\WpOrm\Tests\WordPress\Models;
 use Dbout\WpOrm\Models\Article;
 use Dbout\WpOrm\Models\Meta\PostMeta;
 use Dbout\WpOrm\Models\Post;
+use Dbout\WpOrm\Concerns\HasMeta;
 use Dbout\WpOrm\Tests\WordPress\TestCase;
 
 class ModelWithMetaTest extends TestCase
@@ -19,7 +20,7 @@ class ModelWithMetaTest extends TestCase
      * @return void
      * @covers HasMeta::setMeta
      */
-    public function testSetMetaWithNewModel(): void
+    public function _testSetMetaWithNewModel(): void
     {
         $model = new Article();
         $model->setPostName('hello-world');
@@ -48,5 +49,19 @@ class ModelWithMetaTest extends TestCase
 
         $loadedMeta = $model->getMeta('build-by');
         $this->assertEquals($meta->getId(), $loadedMeta->getId());
+    }
+
+    /**
+     * @return void
+     * @covers HasMeta::hasMeta
+     */
+    public function testHasMeta(): void
+    {
+        $model = new Post();
+        $model->setPostTitle('Hello world');
+        $model->save();
+
+        $model->setMeta('birthday-date', '17/09/1900');
+        $this->assertTrue($model->hasMeta('birthday-date'));
     }
 }

--- a/tests/WordPress/Models/ModelWithMetaTest.php
+++ b/tests/WordPress/Models/ModelWithMetaTest.php
@@ -28,6 +28,7 @@ class ModelWithMetaTest extends TestCase
         $meta = $model->setMeta('build-by', 'Dimitri B.');
         $model->save();
 
+        var_dump('__testSetMetaWithNewModel', $model->getId(), get_post_meta($model->getId(), 'build-by', true));
         $this->assertEquals('Dimitri B.', get_post_meta($model->getId(), 'build-by', true));
         $this->assertEquals(null, $meta, 'The function must return null because the model does not yet exist.');
     }
@@ -43,6 +44,8 @@ class ModelWithMetaTest extends TestCase
 
         $model->save();
         $meta = $model->setMeta('build-by', 'John D.');
+
+        var_dump('__testSetMetaWithExistingModel', $model->getId(), get_post_meta($model->getId(), 'build-by', true));
 
         $this->assertEquals('John D.', get_post_meta($model->getId(), 'build-by', true));
         $this->assertInstanceOf(PostMeta::class, $meta);

--- a/tests/WordPress/Models/ModelWithMetaTest.php
+++ b/tests/WordPress/Models/ModelWithMetaTest.php
@@ -27,7 +27,7 @@ class ModelWithMetaTest extends TestCase
         $meta = $model->setMeta('build-by', 'Dimitri B.');
         $model->save();
 
-        $this->assertEquals('Dimitri B.', get_post_meta($model->getId(), 'build-by'));
+        $this->assertEquals('Dimitri B.', get_post_meta($model->getId(), 'build-by', true));
         $this->assertEquals(null, $meta, 'The function must return null because the model does not yet exist.');
     }
 
@@ -43,7 +43,7 @@ class ModelWithMetaTest extends TestCase
         $model->save();
         $meta = $model->setMeta('build-by', 'John D.');
 
-        $this->assertEquals('John D.', get_post_meta($model->getId(), 'build-by'));
+        $this->assertEquals('John D.', get_post_meta($model->getId(), 'build-by', true));
         $this->assertInstanceOf(PostMeta::class, $meta);
 
         $loadedMeta = $model->getMeta('build-by');


### PR DESCRIPTION
When `HasMeta::setMeta()` is used, the value is saved in database but `meta_key` column is always empty.