### PR TITLE
Discover problems in tests/WordPress

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,8 @@
 parameters:
-    level: 5
+    #level: 5
+    level: 0
     paths:
         - src
         - tests
-    excludePaths:
-        - tests/WordPress
+    scanFiles:
+        - vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php


### PR DESCRIPTION
This is not a PR.

You can discover problems in tests with the help of `php-stubs/wordpress-tests-stubs`.