### PR TITLE
Extends WordPressGrammar from MySqlGrammar

### DIFF
--- a/src/Orm/Query/Grammars/WordPressGrammar.php
+++ b/src/Orm/Query/Grammars/WordPressGrammar.php
@@ -8,42 +8,8 @@
 
 namespace Dbout\WpOrm\Orm\Query\Grammars;
 
-use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 
-/**
- * @todo Extend from MySqlGrammar next major version
- * @see MySqlGrammar
- */
-class WordPressGrammar extends Grammar
+class WordPressGrammar extends MySqlGrammar
 {
-    /**
-     * @inheritDoc
-     */
-    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update): string
-    {
-        // @phpstan-ignore-next-line
-        $useUpsertAlias = $query->connection->getConfig('use_upsert_alias');
-
-        $sql = $this->compileInsert($query, $values);
-
-        if ($useUpsertAlias) {
-            $sql .= ' as laravel_upsert_alias';
-        }
-
-        $sql .= ' on duplicate key update ';
-
-        $columns = collect($update)->map(function ($value, $key) use ($useUpsertAlias) {
-            if (! is_numeric($key)) {
-                return $this->wrap($key).' = '.$this->parameter($value);
-            }
-
-            return $useUpsertAlias
-                ? $this->wrap($value).' = '.$this->wrap('laravel_upsert_alias').'.'.$this->wrap($value)
-                : $this->wrap($value).' = values('.$this->wrap($value).')';
-        })->implode(', ');
-
-        return $sql.$columns;
-    }
 }

--- a/tests/WordPress/Orm/DatabaseTest.php
+++ b/tests/WordPress/Orm/DatabaseTest.php
@@ -12,9 +12,6 @@ use Dbout\WpOrm\Models\Post;
 use Dbout\WpOrm\Orm\Database;
 use Dbout\WpOrm\Tests\WordPress\TestCase;
 
-/**
- * @coversDefaultClass \Dbout\WpOrm\Orm\Database
- */
 class DatabaseTest extends TestCase
 {
     private Database $database;
@@ -29,7 +26,7 @@ class DatabaseTest extends TestCase
 
     /**
      * @return void
-     * @covers ::getTablePrefix
+     * @covers Database::getTablePrefix
      */
     public function testGetTablePrefix(): void
     {
@@ -39,8 +36,8 @@ class DatabaseTest extends TestCase
 
     /**
      * @return void
-     * @covers ::getDatabaseName
-     * @covers ::getConfig
+     * @covers Database::getDatabaseName
+     * @covers Database::getConfig
      */
     public function testGetDatabaseName(): void
     {
@@ -49,8 +46,8 @@ class DatabaseTest extends TestCase
 
     /**
      * @return void
-     * @covers ::getName
-     * @covers ::getConfig
+     * @covers Database::getName
+     * @covers Database::getConfig
      */
     public function testGetName(): void
     {
@@ -62,7 +59,7 @@ class DatabaseTest extends TestCase
      * @param string|null $alias
      * @param string $expectedQuery
      * @return void
-     * @covers ::table
+     * @covers Database::table
      * @dataProvider providerTestTable
      */
     public function testTable(string $table, ?string $alias, string $expectedQuery): void
@@ -79,19 +76,19 @@ class DatabaseTest extends TestCase
         yield 'Without alias' => [
             'options',
             null,
-            sprintf('select * from "%s"', $this->getTable('options')),
+            sprintf('select * from `%s`', $this->getTable('options')),
         ];
 
         yield 'With alias' => [
             'options',
             'opts',
-            sprintf('select * from "%s" as "opts"', $this->getTable('options')),
+            sprintf('select * from `%s` as `opts`', $this->getTable('options')),
         ];
     }
 
     /**
      * @return void
-     * @covers ::lastInsertId
+     * @covers Database::lastInsertId
      */
     public function testLastInsertId(): void
     {


### PR DESCRIPTION
Migrate to MySqlGrammar :rocket:

Source issue: https://github.com/dimitriBouteille/wp-orm/issues/66