### PR TITLE
[FEATURE]: Add support for JSON columns

### DIFF
--- a/src/Orm/AbstractModel.php
+++ b/src/Orm/AbstractModel.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * @method static \int upsert(array $values, array|string $uniqueBy, array|null $update = null) Insert new records or update the existing ones.
  * @method static static|null find(int|string $objectId) Retrieve a model by its primary key.
+ * @method static void truncate() Delete all the model's associated database records, operation will also reset any auto-incrementing IDs on the model's associated table.
  */
 abstract class AbstractModel extends Model
 {

--- a/src/Orm/AbstractModel.php
+++ b/src/Orm/AbstractModel.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \int upsert(array $values, array|string $uniqueBy, array|null $update = null) Insert new records or update the existing ones.
  * @method static static|null find(int|string $objectId) Retrieve a model by its primary key.
  * @method static void truncate() Delete all the model's associated database records, operation will also reset any auto-incrementing IDs on the model's associated table.
+ * @method static void insert(array $data) Insert new records into the database.
  */
 abstract class AbstractModel extends Model
 {

--- a/src/Orm/AbstractModel.php
+++ b/src/Orm/AbstractModel.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \int upsert(array $values, array|string $uniqueBy, array|null $update = null) Insert new records or update the existing ones.
  * @method static static|null find(int|string $objectId) Retrieve a model by its primary key.
  * @method static void truncate() Delete all the model's associated database records, operation will also reset any auto-incrementing IDs on the model's associated table.
- * @method static void insert(array $data) Insert new records into the database.
  */
 abstract class AbstractModel extends Model
 {

--- a/src/Orm/Database.php
+++ b/src/Orm/Database.php
@@ -143,7 +143,7 @@ class Database extends Connection
      */
     private function bindParams(?string $query, array $bindings): string
     {
-        $query = \str_replace('"', '`', (string)$query);
+        //$query = \str_replace('"', '`', (string)$query);
         $bindings = $this->prepareBindings($bindings);
         if ($bindings === []) {
             return $query;

--- a/src/Orm/Database.php
+++ b/src/Orm/Database.php
@@ -143,11 +143,7 @@ class Database extends Connection
      */
     private function bindParams(?string $query, array $bindings): string
     {
-        /**
-         * Fix issue with JSON path
-         * @see https://stackoverflow.com/a/35735594
-         */
-        //$query = \str_replace('"', '`', (string)$query);
+        $query = \str_replace('"', '`', (string)$query);
         $bindings = $this->prepareBindings($bindings);
         if ($bindings === []) {
             return $query;

--- a/src/Orm/Database.php
+++ b/src/Orm/Database.php
@@ -143,6 +143,10 @@ class Database extends Connection
      */
     private function bindParams(?string $query, array $bindings): string
     {
+        /**
+         * Fix issue with JSON path
+         * @see https://stackoverflow.com/a/35735594
+         */
         //$query = \str_replace('"', '`', (string)$query);
         $bindings = $this->prepareBindings($bindings);
         if ($bindings === []) {

--- a/src/Orm/Query/Grammars/WordPressGrammar.php
+++ b/src/Orm/Query/Grammars/WordPressGrammar.php
@@ -12,4 +12,13 @@ use Illuminate\Database\Query\Grammars\MySqlGrammar;
 
 class WordPressGrammar extends MySqlGrammar
 {
+    /**
+     * @inheritDoc
+     */
+    protected function wrapJsonSelector($value): string
+    {
+        [$field, $path] = $this->wrapJsonFieldAndPath($value);
+        $path = \str_replace('"', '', $path);
+        return 'json_unquote(json_extract('.$field.$path.'))';
+    }
 }

--- a/src/Orm/Query/Grammars/WordPressGrammar.php
+++ b/src/Orm/Query/Grammars/WordPressGrammar.php
@@ -13,6 +13,9 @@ use Illuminate\Database\Query\Grammars\MySqlGrammar;
 class WordPressGrammar extends MySqlGrammar
 {
     /**
+     * Fix issue with JSON path
+     * @see https://github.com/dimitriBouteille/wp-orm/pull/93
+     * @see https://stackoverflow.com/a/35735594
      * @inheritDoc
      */
     protected function wrapJsonSelector($value): string

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -221,8 +221,9 @@ class AbstractModelWithCustomTableTest extends TestCase
     /**
      * @return void
      * @covers AbstractModel::truncate
+     * @covers AbstractModel::insert
      */
-    public function testTruncate(): void
+    public function testInsertAndTruncate(): void
     {
         $data = [
             [
@@ -242,7 +243,10 @@ class AbstractModelWithCustomTableTest extends TestCase
             ],
         ];
 
-        var_dump(self::$model::insert($data));
+        self::$model::insert($data);
+        $this->assertEquals(3, self::$model::all()->count());
+
         self::$model::truncate();
+        $this->assertEquals(0, self::$model::all()->count());
     }
 }

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -217,4 +217,32 @@ class AbstractModelWithCustomTableTest extends TestCase
         $newObject = self::$model::find($id);
         $this->assertNull($newObject);
     }
+
+    /**
+     * @return void
+     * @covers AbstractModel::truncate
+     */
+    public function testTruncate(): void
+    {
+        $data = [
+            [
+                'name' => 'Martin Garrix',
+                'url' => 'martin-garrix',
+                'metadata' => ['type' => 'edm'],
+            ],
+            [
+                'name' => 'Marshmello',
+                'url' => 'marshmello',
+                'metadata' => ['type' => 'edm'],
+            ],
+            [
+                'name' => 'Calvin Harris',
+                'url' => 'calvin-harris',
+                'metadata' => ['type' => 'edm'],
+            ],
+        ];
+
+        self::$model::insert($data);
+        var_dump(self::$model::truncate());
+    }
 }

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -88,20 +88,55 @@ class AbstractModelWithCustomTableTest extends TestCase
 
     /**
      * @return void
-     * @covers AbstractModel::all
-     */
-    public function testAll(): void
-    {
-
-    }
-
-    /**
-     * @return void
      * @covers AbstractModel::query
      */
     public function testWhereWithJsonColumn(): void
     {
+        $seArtists = [
+            [
+                'name' => 'Avicii',
+                'url' => 'avicii',
+                'metadata' => ['birthday-date' => '08-09-1989', 'address' => ['city' => 'Stockholm', 'country' => 'SE']],
+            ],
+            [
+                'name' => 'Basshunter',
+                'url' => 'basshunter',
+                'metadata' => ['birthday-date' => '22-12-1984', 'address' => ['city' => 'Halmstad', 'country' => 'SE']],
+            ],
+            [
+                'name' => 'Måns Zelmerlöw',
+                'url' => 'mans-zelmerlow',
+                'metadata' => ['birthday-date' => '11-06-1986', 'address' => ['city' => 'Lund', 'country' => 'SE']],
+            ],
+        ];
 
+        $seIds = [];
+        foreach ($seArtists as $artist) {
+            $model = new self::$model($artist);
+            $model->save();
+            $seIds[] = $model->getId();
+        }
+
+        $frArtists = [
+            [
+                'name' => 'Madeon',
+                'url' => 'madeon',
+                'metadata' => ['birthday-date' => '30-05-1994', 'address' => ['city' => 'Nantes', 'country' => 'FR']],
+            ],
+            [
+                'name' => 'Kavinsky',
+                'url' => 'kavinsky',
+                'metadata' => ['birthday-date' => '31-07-1975', 'address' => ['city' => 'Seine-Saint-Denis', 'country' => 'FR']],
+            ],
+        ];
+
+        foreach ($frArtists as $artist) {
+            $model = new self::$model($artist);
+            $model->save();
+        }
+
+        $selectedIds = self::$model::query()->where('metadata->address->country', 'SE')->get()->pluck('id');
+        $this->assertEquals($seIds, $selectedIds);
     }
 
     /**

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -242,7 +242,7 @@ class AbstractModelWithCustomTableTest extends TestCase
             ],
         ];
 
-        self::$model::insert($data);
-        var_dump(self::$model::truncate());
+        var_dump(self::$model::insert($data));
+        self::$model::truncate();
     }
 }

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -143,7 +143,8 @@ class AbstractModelWithCustomTableTest extends TestCase
             $model->save();
         }
 
-        $selectedIds = self::$model::query()->where('metadata->address.country', 'SE')->get()->pluck('id');
+        $selectedIds = self::$model::query()->where('metadata->address.country', 'SE')->get()->pluck('id')->toArray();
+        $this->assertLastQueryEquals("select * from `eol_wp_659efecustom_table` where json_unquote(json_extract(`metadata`, '$.address.country')) = 'SE'");
         $this->assertEquals($seIds, $selectedIds);
     }
 
@@ -191,7 +192,8 @@ class AbstractModelWithCustomTableTest extends TestCase
             $model->save();
         }
 
-        $selectedIds = self::$model::query()->where('metadata->type', 'edm')->get()->pluck('id');
+        $selectedIds = self::$model::query()->where('metadata->type', 'edm')->get()->pluck('id')->toArray();
+        $this->assertLastQueryEquals("select * from `eol_wp_659efecustom_table` where json_unquote(json_extract(`metadata`, '$.type')) = 'edm'");
         $this->assertEquals($edmIds, $selectedIds);
     }
 

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -49,6 +49,14 @@ class AbstractModelWithCustomTableTest extends TestCase
 
     /**
      * @return void
+     */
+    public function setUp(): void
+    {
+        self::$model::truncate();
+    }
+
+    /**
+     * @return void
      * @covers AbstractModel::save
      */
     public function testSave(): void
@@ -90,7 +98,7 @@ class AbstractModelWithCustomTableTest extends TestCase
      * @return void
      * @covers AbstractModel::query
      */
-    public function testWhereWithJsonColumn(): void
+    public function testWhereWithComplexJsonColumn(): void
     {
         $seArtists = [
             [
@@ -135,8 +143,56 @@ class AbstractModelWithCustomTableTest extends TestCase
             $model->save();
         }
 
-        $selectedIds = self::$model::query()->where('metadata->address->country', 'SE')->get()->pluck('id');
+        $selectedIds = self::$model::query()->where('metadata->address.country', 'SE')->get()->pluck('id');
         $this->assertEquals($seIds, $selectedIds);
+    }
+
+    /**
+     * @return void
+     * @covers AbstractModel::query
+     */
+    public function testWhereWithSimpleJsonColum(): void
+    {
+        $edmArtists = [
+            [
+                'name' => 'Martin Garrix',
+                'url' => 'martin-garrix',
+                'metadata' => ['type' => 'edm'],
+            ],
+            [
+                'name' => 'Marshmello',
+                'url' => 'marshmello',
+                'metadata' => ['type' => 'edm'],
+            ],
+            [
+                'name' => 'Calvin Harris',
+                'url' => 'calvin-harris',
+                'metadata' => ['type' => 'edm'],
+            ],
+        ];
+
+        $edmIds = [];
+        foreach ($edmArtists as $artist) {
+            $model = new self::$model($artist);
+            $model->save();
+            $edmIds[] = $model->getId();
+        }
+
+        $popArtists = [
+            [
+                'name' => 'Coldplay',
+                'url' => 'coldplay',
+                'metadata' => ['type' => 'pop'],
+            ],
+        ];
+
+        foreach ($popArtists as $artist) {
+            $model = new self::$model($artist);
+            $model->save();
+        }
+
+        $selectedIds = self::$model::query()->where('metadata->type', 'edm')->get()->pluck('id');
+        $this->assertEquals($edmIds, $selectedIds);
     }
 
     /**

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -39,6 +39,8 @@ class AbstractModelWithCustomTableTest extends TestCase
             protected $primaryKey = 'id';
             public $timestamps = false;
 
+            protected $table = 'custom_table';
+
             protected $casts = [
                 'metadata' => 'json',
             ];

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Orm;
+
+use Dbout\WpOrm\Orm\AbstractModel;
+use Dbout\WpOrm\Tests\WordPress\TestCase;
+
+class AbstractModelWithCustomTableTest extends TestCase
+{
+    private const TABLE_NAME = 'custom_table';
+    private static AbstractModel $model;
+
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        global $wpdb;
+
+        $tableName = $wpdb->prefix . self::TABLE_NAME;
+        $sql = "CREATE TABLE $tableName (
+            id INT NOT NULL AUTO_INCREMENT,
+            name varchar(100) NOT NULL,
+            url varchar(55) DEFAULT '' NOT NULL,
+            metadata JSON,
+            PRIMARY KEY  (id)
+        );";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($sql);
+
+        self::$model = new class () extends AbstractModel {
+            protected $primaryKey = 'id';
+            public $timestamps = false;
+
+            protected $casts = [
+                'metadata' => 'json',
+            ];
+        };
+    }
+
+    /**
+     * @return void
+     * @covers AbstractModel::save
+     */
+    public function testSave(): void
+    {
+        $metaData = ['birthday-date' => '01-06-1935', 'address' => ['city' => 'London', 'zipcode' => 'London']];
+
+        /** @var AbstractModel $object */
+        $object = new self::$model();
+        $object->setAttribute('name', 'Norman FOSTER');
+        $object->setAttribute('url', 'norman-forster');
+        $object->setAttribute('metadata', $metaData);
+        $this->assertTrue($object->save());
+
+        $this->assertEquals('Norman FOSTER', $object->getAttribute('name'));
+        $this->assertEquals('norman-forster', $object->getAttribute('url'));
+        $this->assertEquals($metaData, $object->getAttribute('metadata'));
+    }
+
+    /**
+     * @return void
+     * @covers AbstractModel::find
+     */
+    public function testFind(): void
+    {
+        /** @var AbstractModel $object */
+        $object = new self::$model([
+            'name' => 'Zaha Hadid',
+            'url' => 'zaha-hadid',
+            'metadata' => ['birthday-date' => '31-10-1950', 'address' => ['city' => 'Bagdad']],
+        ]);
+
+        $this->assertTrue($object->save());
+
+        $newObject = self::$model::find($object->getId());
+        $this->assertInstanceOf(AbstractModel::class, $newObject);
+    }
+
+    /**
+     * @return void
+     * @covers AbstractModel::all
+     */
+    public function testAll(): void
+    {
+
+    }
+
+    /**
+     * @return void
+     * @covers AbstractModel::query
+     */
+    public function testWhereWithJsonColumn(): void
+    {
+
+    }
+
+    /**
+     * @return void
+     * @covers AbstractModel::delete
+     */
+    public function testDelete(): void
+    {
+        /** @var AbstractModel $object */
+        $object = new self::$model([
+            'name' => 'Frank Gehry',
+            'url' => 'frank-gehry',
+            'metadata' => ['birthday-date' => '28-02-1929', 'address' => ['city' => 'Toronto']],
+        ]);
+
+        $this->assertTrue($object->save());
+        $id = $object->getId();
+        $this->assertTrue($object->delete());
+
+        $newObject = self::$model::find($id);
+        $this->assertNull($newObject);
+    }
+}

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -221,9 +221,8 @@ class AbstractModelWithCustomTableTest extends TestCase
     /**
      * @return void
      * @covers AbstractModel::truncate
-     * @covers AbstractModel::insert
      */
-    public function testInsertAndTruncate(): void
+    public function testTruncate(): void
     {
         $data = [
             [
@@ -243,7 +242,12 @@ class AbstractModelWithCustomTableTest extends TestCase
             ],
         ];
 
-        self::$model::insert($data);
+        foreach ($data as $item) {
+            /** @var AbstractModel $e */
+            $e = new self::$model($item);
+            $e->save();
+        }
+
         $this->assertEquals(3, self::$model::all()->count());
 
         self::$model::truncate();

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -144,7 +144,7 @@ class AbstractModelWithCustomTableTest extends TestCase
         }
 
         $selectedIds = self::$model::query()->where('metadata->address.country', 'SE')->get()->pluck('id')->toArray();
-        $this->assertLastQueryEquals("select * from `eol_wp_659efecustom_table` where json_unquote(json_extract(`metadata`, '$.address.country')) = 'SE'");
+        $this->assertLastQueryEquals("select * from `#TABLE_PREFIX#custom_table` where json_unquote(json_extract(`metadata`, '$.address.country')) = 'SE'");
         $this->assertEquals($seIds, $selectedIds);
     }
 
@@ -193,7 +193,7 @@ class AbstractModelWithCustomTableTest extends TestCase
         }
 
         $selectedIds = self::$model::query()->where('metadata->type', 'edm')->get()->pluck('id')->toArray();
-        $this->assertLastQueryEquals("select * from `eol_wp_659efecustom_table` where json_unquote(json_extract(`metadata`, '$.type')) = 'edm'");
+        $this->assertLastQueryEquals("select * from `#TABLE_PREFIX#custom_table` where json_unquote(json_extract(`metadata`, '$.type')) = 'edm'");
         $this->assertEquals($edmIds, $selectedIds);
     }
 


### PR DESCRIPTION
Fixes #88 

---

Edit `MySqlGrammar::wrapJsonFieldAndPath()` and remove `"` from path, because this generated query not working with mysql : 

❌​

```sql
select * 
from `eol_wp_659efecustom_table` 
where json_unquote(json_extract(`metadata`, '$."address.country"')) = 'SE'
```
But this query works ✅ : 

```sql
select * 
from `eol_wp_659efecustom_table`
where json_unquote(json_extract(`metadata`, '$.address.country')) = 'SE'
```
---

✅ With simple child no problem, I don't know why :(

```sql
select * 
from `eol_wp_659efecustom_table` 
where json_unquote(json_extract(`metadata`, '$."country"')) = 'SE'
```


