### PR TITLE
Release v4.0.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:9.0
+        image: mysql:9.1
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
         ports:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        wp_version: ["6.3", "6.4", "6.5", "6.6", "latest"]
+        wp_version: ["6.3", "6.4", "6.5", "6.6", "6.7", "latest"]
 
     services:
       mysql:

--- a/composer.json
+++ b/composer.json
@@ -39,13 +39,13 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.64",
-    "phpstan/phpstan": "^1.12",
-    "phpstan/extension-installer": "^1.4",
-    "szepeviktor/phpstan-wordpress": "^1.3",
-    "rector/rector": "^1.2",
     "roots/wordpress": "^6.6",
     "phpunit/phpunit": "^11.0",
-    "yoast/phpunit-polyfills": "^3.0"
+    "yoast/phpunit-polyfills": "^3.0",
+    "phpstan/phpstan": "^2.0",
+    "rector/rector": "^2.0",
+    "phpstan/extension-installer": "^1.4",
+    "szepeviktor/phpstan-wordpress": "^2.0"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=8.2",
-    "laravel/serializable-closure": "^1.3",
+    "laravel/serializable-closure": ">=1.3",
     "illuminate/database": "^11.0"
   },
   "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,4 +4,7 @@ parameters:
         - src
         - tests
     excludePaths:
-        - tests/WordPress/TestCase
+        - tests/WordPress/TestCase.php
+    ignoreErrors:
+        -
+            identifier: requireOnce.fileNotFound

--- a/src/Orm/AbstractModel.php
+++ b/src/Orm/AbstractModel.php
@@ -11,7 +11,7 @@ namespace Dbout\WpOrm\Orm;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @method static \int upsert(array $values, array|string $uniqueBy, array|null $update = null) Insert new records or update the existing ones.
+ * @method static int upsert(array $values, array|string $uniqueBy, array|null $update = null) Insert new records or update the existing ones.
  * @method static static|null find(int|string $objectId) Retrieve a model by its primary key.
  * @method static void truncate() Delete all the model's associated database records, operation will also reset any auto-incrementing IDs on the model's associated table.
  */

--- a/src/Orm/Database.php
+++ b/src/Orm/Database.php
@@ -467,6 +467,7 @@ class Database extends Connection
      */
     public function getSchemaBuilder(): \Illuminate\Database\Schema\Builder
     {
+        // @phpstan-ignore-next-line
         if (!$this->schemaGrammar instanceof Grammar) {
             $this->useDefaultSchemaGrammar();
         }


### PR DESCRIPTION
- [Update to phpstan/phpstan 2.0](https://github.com/dimitriBouteille/wp-orm/pull/104)
- [Run WordPress tests with v6.7](https://github.com/dimitriBouteille/wp-orm/pull/106)
- [Use mysql:9.1 in tests](https://github.com/dimitriBouteille/wp-orm/pull/108)
- [Update laravel/serializable-closure to >=1.3](https://github.com/dimitriBouteille/wp-orm/pull/109)