### PR TITLE
💎 Add local testing env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# MySQL Configuration for WordPress tests
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=wordpress_test
+
+# WordPress version to test against
+# Options: 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, latest
+WP_VERSION=latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ composer.lock
 web
 /package-lock.json
 build/
+.env

--- a/README.md
+++ b/README.md
@@ -59,6 +59,32 @@ require __DIR__ . '/vendor/autoload.php';
 
 🎉 You have nothing more to do, you can use the library now! Not even need to configure database accesses because it's the `wpdb` connection that is used.
 
+## Testing
+
+🐞 This project includes two types of tests:
+
+- **Unit tests** - Isolated tests without WordPress dependencies (PHPUnit 11)
+- **WordPress tests** - Integration tests with WordPress core (PHPUnit 9)
+
+**Running tests:**
+
+```bash
+# Unit tests
+composer run test:unit
+
+# WordPress tests (requires Docker)
+./run-wp-tests.sh
+
+# With coverage
+./run-wp-tests.sh --coverage
+```
+
+**Local setup:**
+
+WordPress tests require Docker and Subversion. The `run-wp-tests.sh` script automatically sets up a MySQL container and installs WordPress test environment. WordPress files are cached in `var/testings/` for faster subsequent runs.
+
+See [TESTING.md](TESTING.md) for detailed setup instructions and troubleshooting.
+
 ## Contributing
 
-We encourage you to contribute to this repository, so everyone can benefit from new features, bug fixes, and any other improvements. Have a look at our [contributing guidelines](CONTRIBUTING.md) to find out how to raise a pull request.
+💕 🦄 We encourage you to contribute to this repository, so everyone can benefit from new features, bug fixes, and any other improvements. Have a look at our [contributing guidelines](CONTRIBUTING.md) to find out how to raise a pull request.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,147 @@
+# WordPress Tests - Local Setup Guide
+
+This guide explains how to run WordPress tests locally using Docker Compose.
+
+## Prerequisites
+
+- Docker and Docker Compose installed on your machine
+- PHP 8.2+ installed locally
+- Composer installed
+- Subversion (svn) to download WordPress test files:
+  ```bash
+  sudo apt-get install -y subversion  # Ubuntu/Debian
+  sudo yum install -y subversion      # CentOS/RHEL
+  brew install svn                    # macOS
+  ```
+
+## Initial Setup
+
+### 1. Install dependencies
+
+```bash
+composer install
+```
+
+### 2. Configure environment (Optional)
+
+Copy the `.env.example` file to `.env` if you want to customize the configuration:
+
+```bash
+cp .env.example .env
+```
+
+You can modify the following values in the `.env` file:
+
+```bash
+# MySQL root password (default: root)
+MYSQL_ROOT_PASSWORD=root
+
+# Test database name (default: wordpress_test)
+MYSQL_DATABASE=wordpress_test
+
+# WordPress version to test against (default: latest)
+# Options: 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, latest
+WP_VERSION=latest
+```
+
+## Running Tests
+
+### Quick method with automated script
+
+```bash
+# Run tests without coverage
+./run-wp-tests.sh
+
+# Run tests with coverage
+./run-wp-tests.sh --coverage
+```
+
+The `run-wp-tests.sh` script automatically:
+1. Starts the MySQL container
+2. Creates/resets the test database
+3. Installs PHPUnit 9 (required for WordPress)
+4. Installs WordPress test environment (if not already present)
+5. Runs the tests
+
+**Note:** WordPress and test files are installed in `var/testings/` and will be reused on subsequent runs for faster execution.
+
+## Testing Different WordPress Versions
+
+To test with a specific WordPress version:
+
+```bash
+# Using .env file
+echo "WP_VERSION=6.7" > .env
+./run-wp-tests.sh
+
+# Or directly via command line
+WP_VERSION=6.7 ./run-wp-tests.sh
+```
+
+## Reinstalling the Test Environment
+
+If you encounter issues, you can completely reinstall the environment:
+
+```bash
+# 1. Clean Docker
+docker compose down -v
+
+# 2. Remove WordPress files
+rm -rf var/testings
+
+# 3. Rerun tests
+./run-wp-tests.sh
+```
+
+### Tests fail after changing WordPress version
+
+```bash
+# Reinstall the test environment
+rm -rf var/testings
+./run-wp-tests.sh
+```
+
+### SVN not found error
+
+Make sure Subversion is installed:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install -y subversion
+
+# Check installation
+svn --version
+```
+
+## Unit Tests (without WordPress)
+
+To run only unit tests (which don't require WordPress):
+
+```bash
+composer run test:unit
+```
+
+## Test Architecture
+
+- **Unit tests**: `tests/Unit/` - Isolated tests without WordPress dependencies
+- **WordPress tests**: `tests/WordPress/` - Integration tests with WordPress
+- **PHPUnit configuration**:
+  - `phpunit.xml` : Unit tests (PHPUnit 11)
+  - `phpunit-wp.xml` : WordPress tests (PHPUnit 9)
+
+## Important Notes
+
+- WordPress tests require **PHPUnit 9** only (WordPress limitation)
+- The MySQL container uses port **3307** to avoid conflicts with local MySQL installations
+- WordPress files are stored in `var/testings/wordpress` (local to project)
+- Test suite files are stored in `var/testings/tests-wp` (local to project)
+- The `run-wp-tests.sh` script automatically installs PHPUnit 9
+- The database is dropped and recreated on each test run to ensure a clean state
+- WordPress installation is cached and reused across test runs for better performance
+
+## Performance Tips
+
+- First run will be slower (downloads WordPress and test files)
+- Subsequent runs are faster (WordPress files are cached in `var/testings/`)
+- To force a clean WordPress installation: `rm -rf var/testings`
+- The test database is always reset to ensure consistent test results

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  mysql:
+    image: mysql:9.4
+    container_name: wp-orm-mysql-test
+    ports:
+      - "3307:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-wordpress_test}
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD:-root}"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+    networks:
+      - wp-orm-test
+
+volumes:
+  mysql_data:
+
+networks:
+  wp-orm-test:
+    driver: bridge

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,3 @@ parameters:
         - tests
     excludePaths:
         - tests/WordPress/TestCase.php
-    ignoreErrors:
-        -
-            identifier: requireOnce.fileNotFound

--- a/run-wp-tests.sh
+++ b/run-wp-tests.sh
@@ -9,7 +9,7 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 # Load .env file if exists
-if [ -f .env ]; then
+if [[ -f .env ]]; then
     echo -e "${GREEN}Loading configuration from .env file...${NC}"
     export $(grep -v '^#' .env | xargs)
 fi
@@ -47,7 +47,7 @@ docker compose exec -T mysql mysql -uroot -p${MYSQL_ROOT_PASSWORD} -e "DROP DATA
 echo -e "${GREEN}Database ready!${NC}"
 echo ""
 
-if [ ! -d "vendor" ]; then
+if [[ ! -d "vendor" ]]; then
     echo -e "${RED}Error: vendor directory not found. Please run 'composer install' first.${NC}"
     exit 1
 fi
@@ -56,7 +56,7 @@ fi
 echo -e "${GREEN}Installing PHPUnit 9 (required for WordPress tests)...${NC}"
 composer require --dev --update-with-all-dependencies 'phpunit/phpunit:^9.0' 'yoast/phpunit-polyfills:^3.0' --quiet
 
-if [ -f "${WP_TESTS_DIR}/includes/bootstrap.php" ] && [ -f "${WP_CORE_DIR}/wp-load.php" ]; then
+if [[ -f "${WP_TESTS_DIR}/includes/bootstrap.php" ]] && [[ -f "${WP_CORE_DIR}/wp-load.php" ]]; then
     echo -e "${GREEN}WordPress test suite already installed, skipping...${NC}"
 else
     echo -e "${GREEN}Installing WordPress test suite...${NC}"
@@ -67,7 +67,7 @@ echo ""
 echo -e "${GREEN}=== Running WordPress Tests ===${NC}"
 echo ""
 
-if [ "$1" == "--coverage" ]; then
+if [[ "$1" == "--coverage" ]]; then
     echo -e "${GREEN}Running tests with coverage...${NC}"
     composer run test:wordPress:coverage
 else

--- a/run-wp-tests.sh
+++ b/run-wp-tests.sh
@@ -48,7 +48,7 @@ echo -e "${GREEN}Database ready!${NC}"
 echo ""
 
 if [[ ! -d "vendor" ]]; then
-    echo -e "${RED}Error: vendor directory not found. Please run 'composer install' first.${NC}"
+    echo -e "${RED}Error: vendor directory not found. Please run 'composer install' first.${NC}" >&2
     exit 1
 fi
 

--- a/run-wp-tests.sh
+++ b/run-wp-tests.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Load .env file if exists
+if [ -f .env ]; then
+    echo -e "${GREEN}Loading configuration from .env file...${NC}"
+    export $(grep -v '^#' .env | xargs)
+fi
+
+# Default values
+MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
+MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress_test}
+WP_VERSION=${WP_VERSION:-latest}
+DB_HOST="127.0.0.1:3307"
+
+# Set WordPress test directories (local to project)
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export WP_TESTS_DIR="${PROJECT_DIR}/var/testings/tests-wp"
+export WP_CORE_DIR="${PROJECT_DIR}/var/testings/wordpress"
+
+echo -e "${GREEN}=== WordPress Test Environment Setup ===${NC}"
+echo -e "Database: ${YELLOW}${MYSQL_DATABASE}${NC}"
+echo -e "WordPress Version: ${YELLOW}${WP_VERSION}${NC}"
+echo ""
+
+echo -e "${GREEN}Starting MySQL container...${NC}"
+docker compose up -d mysql
+
+# Wait for MySQL to be ready
+echo -e "${GREEN}Waiting for MySQL to be ready...${NC}"
+until docker compose exec -T mysql mysqladmin ping -h localhost -uroot -p${MYSQL_ROOT_PASSWORD} --silent &> /dev/null; do
+    echo -e "${YELLOW}Waiting for MySQL...${NC}"
+    sleep 2
+done
+echo -e "${GREEN}MySQL is ready!${NC}"
+echo ""
+
+echo -e "${GREEN}Creating test database...${NC}"
+docker compose exec -T mysql mysql -uroot -p${MYSQL_ROOT_PASSWORD} -e "DROP DATABASE IF EXISTS ${MYSQL_DATABASE}; CREATE DATABASE ${MYSQL_DATABASE};" 2>/dev/null
+echo -e "${GREEN}Database ready!${NC}"
+echo ""
+
+if [ ! -d "vendor" ]; then
+    echo -e "${RED}Error: vendor directory not found. Please run 'composer install' first.${NC}"
+    exit 1
+fi
+
+# Install PHPUnit 9 (required for WordPress tests)
+echo -e "${GREEN}Installing PHPUnit 9 (required for WordPress tests)...${NC}"
+composer require --dev --update-with-all-dependencies 'phpunit/phpunit:^9.0' 'yoast/phpunit-polyfills:^3.0' --quiet
+
+if [ -f "${WP_TESTS_DIR}/includes/bootstrap.php" ] && [ -f "${WP_CORE_DIR}/wp-load.php" ]; then
+    echo -e "${GREEN}WordPress test suite already installed, skipping...${NC}"
+else
+    echo -e "${GREEN}Installing WordPress test suite...${NC}"
+    ./config/scripts/install-wp-tests.sh ${MYSQL_DATABASE} root ${MYSQL_ROOT_PASSWORD} ${DB_HOST} ${WP_VERSION} true
+fi
+
+echo ""
+echo -e "${GREEN}=== Running WordPress Tests ===${NC}"
+echo ""
+
+if [ "$1" == "--coverage" ]; then
+    echo -e "${GREEN}Running tests with coverage...${NC}"
+    composer run test:wordPress:coverage
+else
+    echo -e "${GREEN}Running tests without coverage...${NC}"
+    composer run test:wordPress
+fi
+
+echo ""
+echo -e "${GREEN}=== Tests completed! ===${NC}"
+echo ""
+echo -e "To stop MySQL container: ${YELLOW}docker compose down${NC}"
+echo -e "To clean up everything: ${YELLOW}docker compose down -v${NC}"

--- a/src/Builders/AbstractBuilder.php
+++ b/src/Builders/AbstractBuilder.php
@@ -34,7 +34,7 @@ abstract class AbstractBuilder extends Builder
         $first = reset($value);
         if (is_array($first)) {
             $this->whereIn($columns, $first);
-        } elseif (count($value) == 1) {
+        } elseif (count($value) === 1) {
             $this->where($columns, reset($value));
         } else {
             $this->whereIn($columns, $value);


### PR DESCRIPTION
This branch adds a local WordPress testing environment based on Docker, allowing easy execution of WordPress tests without complex manual configuration.

To run test :

```bash
./run-wp-tests.sh
```