### PR TITLE
Lock rector version, update header license

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -17,8 +17,6 @@ $finder = \PhpCsFixer\Finder::create()
 $header = <<<EOF
     Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
     See LICENSE.txt for license details.
-
-    Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
     EOF;
 
 $config = new \PhpCsFixer\Config();
@@ -30,6 +28,7 @@ return $config
         '@PSR12' => true,
         '@PHP81Migration' => true,
         'strict_param' => true,
+        'declare_strict_types' => true,
         'array_syntax' => ['syntax' => 'short'],
         'octal_notation' => false,
         'trim_array_spaces' => true,
@@ -45,6 +44,6 @@ return $config
             'header' => $header,
             'comment_type' => 'PHPDoc',
             'location' => 'after_open',
-            'separate' => 'bottom',
+            'separate' => 'none',
         ],
     ]);

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -28,7 +28,7 @@ return $config
         '@PSR12' => true,
         '@PHP81Migration' => true,
         'strict_param' => true,
-        'declare_strict_types' => true,
+        'declare_strict_types' => false,
         'array_syntax' => ['syntax' => 'short'],
         'octal_notation' => false,
         'trim_array_spaces' => true,

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^12.5",
-    "rector/rector": "^2.0",
+    "rector/rector": "~2.4.0",
     "phpstan/extension-installer": "^1.4",
     "szepeviktor/phpstan-wordpress": "^2.0",
     "friendsofphp/php-cs-fixer": "^3.68",
@@ -62,6 +62,7 @@
   },
   "scripts": {
     "rector": "vendor/bin/rector process src --dry-run",
+    "fix:rector": "vendor/bin/rector process src",
     "phpstan": "vendor/bin/phpstan analyse -c phpstan.neon",
     "test:unit": "vendor/bin/phpunit --no-coverage",
     "test:unit:coverage": "vendor/bin/phpunit",

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\SetList;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -23,4 +24,7 @@ return RectorConfig::configure()
     )
     ->withSets([
         SetList::PHP_82,
+    ])
+    ->withSkip([
+        SafeDeclareStrictTypesRector::class,
     ]);

--- a/src/Api/CustomModelTypeInterface.php
+++ b/src/Api/CustomModelTypeInterface.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Api;
 

--- a/src/Api/CustomModelTypeInterface.php
+++ b/src/Api/CustomModelTypeInterface.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Api;
 

--- a/src/Api/WithMetaModelInterface.php
+++ b/src/Api/WithMetaModelInterface.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Api;
 

--- a/src/Api/WithMetaModelInterface.php
+++ b/src/Api/WithMetaModelInterface.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Api;
 

--- a/src/Builders/AbstractBuilder.php
+++ b/src/Builders/AbstractBuilder.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/AbstractBuilder.php
+++ b/src/Builders/AbstractBuilder.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/AbstractWithMetaBuilder.php
+++ b/src/Builders/AbstractWithMetaBuilder.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/AbstractWithMetaBuilder.php
+++ b/src/Builders/AbstractWithMetaBuilder.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/CommentBuilder.php
+++ b/src/Builders/CommentBuilder.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/CommentBuilder.php
+++ b/src/Builders/CommentBuilder.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/OptionBuilder.php
+++ b/src/Builders/OptionBuilder.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/OptionBuilder.php
+++ b/src/Builders/OptionBuilder.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/PostBuilder.php
+++ b/src/Builders/PostBuilder.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/PostBuilder.php
+++ b/src/Builders/PostBuilder.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/TermBuilder.php
+++ b/src/Builders/TermBuilder.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/TermBuilder.php
+++ b/src/Builders/TermBuilder.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/UserBuilder.php
+++ b/src/Builders/UserBuilder.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Builders/UserBuilder.php
+++ b/src/Builders/UserBuilder.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Builders;
 

--- a/src/Concerns/HasMetas.php
+++ b/src/Concerns/HasMetas.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Concerns;
 

--- a/src/Concerns/HasMetas.php
+++ b/src/Concerns/HasMetas.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Concerns;
 

--- a/src/Enums/PingStatus.php
+++ b/src/Enums/PingStatus.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Enums;
 

--- a/src/Enums/PingStatus.php
+++ b/src/Enums/PingStatus.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Enums;
 

--- a/src/Enums/PostStatus.php
+++ b/src/Enums/PostStatus.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Enums;
 

--- a/src/Enums/PostStatus.php
+++ b/src/Enums/PostStatus.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Enums;
 

--- a/src/Enums/YesNo.php
+++ b/src/Enums/YesNo.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Enums;
 

--- a/src/Enums/YesNo.php
+++ b/src/Enums/YesNo.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Enums;
 

--- a/src/Exceptions/CannotOverrideCustomTypeException.php
+++ b/src/Exceptions/CannotOverrideCustomTypeException.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Exceptions;
 

--- a/src/Exceptions/CannotOverrideCustomTypeException.php
+++ b/src/Exceptions/CannotOverrideCustomTypeException.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Exceptions;
 

--- a/src/Exceptions/MetaNotSupportedException.php
+++ b/src/Exceptions/MetaNotSupportedException.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Exceptions;
 

--- a/src/Exceptions/MetaNotSupportedException.php
+++ b/src/Exceptions/MetaNotSupportedException.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Exceptions;
 

--- a/src/Exceptions/NotAllowedException.php
+++ b/src/Exceptions/NotAllowedException.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Exceptions;
 

--- a/src/Exceptions/NotAllowedException.php
+++ b/src/Exceptions/NotAllowedException.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Exceptions;
 

--- a/src/Exceptions/WpOrmException.php
+++ b/src/Exceptions/WpOrmException.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Exceptions;
 

--- a/src/Exceptions/WpOrmException.php
+++ b/src/Exceptions/WpOrmException.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Exceptions;
 

--- a/src/MetaMappingConfig.php
+++ b/src/MetaMappingConfig.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm;
 

--- a/src/MetaMappingConfig.php
+++ b/src/MetaMappingConfig.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm;
 

--- a/src/Models/Article.php
+++ b/src/Models/Article.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Article.php
+++ b/src/Models/Article.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Attachment.php
+++ b/src/Models/Attachment.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Attachment.php
+++ b/src/Models/Attachment.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/CustomComment.php
+++ b/src/Models/CustomComment.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/CustomComment.php
+++ b/src/Models/CustomComment.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/CustomPost.php
+++ b/src/Models/CustomPost.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/CustomPost.php
+++ b/src/Models/CustomPost.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Meta/AbstractMeta.php
+++ b/src/Models/Meta/AbstractMeta.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Meta;
 

--- a/src/Models/Meta/AbstractMeta.php
+++ b/src/Models/Meta/AbstractMeta.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Meta;
 

--- a/src/Models/Meta/MetaInterface.php
+++ b/src/Models/Meta/MetaInterface.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Meta;
 

--- a/src/Models/Meta/MetaInterface.php
+++ b/src/Models/Meta/MetaInterface.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Meta;
 

--- a/src/Models/Meta/PostMeta.php
+++ b/src/Models/Meta/PostMeta.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Meta;
 

--- a/src/Models/Meta/PostMeta.php
+++ b/src/Models/Meta/PostMeta.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Meta;
 

--- a/src/Models/Meta/UserMeta.php
+++ b/src/Models/Meta/UserMeta.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Meta;
 

--- a/src/Models/Meta/UserMeta.php
+++ b/src/Models/Meta/UserMeta.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Meta;
 

--- a/src/Models/Multisite/Blog.php
+++ b/src/Models/Multisite/Blog.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/Blog.php
+++ b/src/Models/Multisite/Blog.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/BlogVersion.php
+++ b/src/Models/Multisite/BlogVersion.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/BlogVersion.php
+++ b/src/Models/Multisite/BlogVersion.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/RegistrationLog.php
+++ b/src/Models/Multisite/RegistrationLog.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/RegistrationLog.php
+++ b/src/Models/Multisite/RegistrationLog.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/Signup.php
+++ b/src/Models/Multisite/Signup.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/Signup.php
+++ b/src/Models/Multisite/Signup.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/Site.php
+++ b/src/Models/Multisite/Site.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/Site.php
+++ b/src/Models/Multisite/Site.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/SiteMeta.php
+++ b/src/Models/Multisite/SiteMeta.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Multisite/SiteMeta.php
+++ b/src/Models/Multisite/SiteMeta.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models\Multisite;
 

--- a/src/Models/Option.php
+++ b/src/Models/Option.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Option.php
+++ b/src/Models/Option.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Term.php
+++ b/src/Models/Term.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/Term.php
+++ b/src/Models/Term.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/TermRelationship.php
+++ b/src/Models/TermRelationship.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/TermRelationship.php
+++ b/src/Models/TermRelationship.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/TermTaxonomy.php
+++ b/src/Models/TermTaxonomy.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/TermTaxonomy.php
+++ b/src/Models/TermTaxonomy.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Models;
 

--- a/src/Orm/AbstractModel.php
+++ b/src/Orm/AbstractModel.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm;
 

--- a/src/Orm/AbstractModel.php
+++ b/src/Orm/AbstractModel.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm;
 

--- a/src/Orm/Builder.php
+++ b/src/Orm/Builder.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm;
 

--- a/src/Orm/Builder.php
+++ b/src/Orm/Builder.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm;
 

--- a/src/Orm/Database.php
+++ b/src/Orm/Database.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm;
 

--- a/src/Orm/Database.php
+++ b/src/Orm/Database.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm;
 

--- a/src/Orm/Query/Grammars/WordPressGrammar.php
+++ b/src/Orm/Query/Grammars/WordPressGrammar.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm\Query\Grammars;
 

--- a/src/Orm/Query/Grammars/WordPressGrammar.php
+++ b/src/Orm/Query/Grammars/WordPressGrammar.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm\Query\Grammars;
 

--- a/src/Orm/Query/Processors/WordPressProcessor.php
+++ b/src/Orm/Query/Processors/WordPressProcessor.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm\Query\Processors;
 

--- a/src/Orm/Query/Processors/WordPressProcessor.php
+++ b/src/Orm/Query/Processors/WordPressProcessor.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm\Query\Processors;
 

--- a/src/Orm/Resolver.php
+++ b/src/Orm/Resolver.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm;
 

--- a/src/Orm/Resolver.php
+++ b/src/Orm/Resolver.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm;
 

--- a/src/Orm/Schemas/WordPressBuilder.php
+++ b/src/Orm/Schemas/WordPressBuilder.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm\Schemas;
 

--- a/src/Orm/Schemas/WordPressBuilder.php
+++ b/src/Orm/Schemas/WordPressBuilder.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Orm\Schemas;
 

--- a/src/Scopes/CustomModelTypeScope.php
+++ b/src/Scopes/CustomModelTypeScope.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Scopes;
 

--- a/src/Scopes/CustomModelTypeScope.php
+++ b/src/Scopes/CustomModelTypeScope.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Scopes;
 

--- a/src/Taps/Attachment/IsMimeTypeTap.php
+++ b/src/Taps/Attachment/IsMimeTypeTap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Attachment;
 

--- a/src/Taps/Attachment/IsMimeTypeTap.php
+++ b/src/Taps/Attachment/IsMimeTypeTap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Attachment;
 

--- a/src/Taps/Comment/IsApprovedTap.php
+++ b/src/Taps/Comment/IsApprovedTap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Comment;
 

--- a/src/Taps/Comment/IsApprovedTap.php
+++ b/src/Taps/Comment/IsApprovedTap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Comment;
 

--- a/src/Taps/Comment/IsCommentTypeTap.php
+++ b/src/Taps/Comment/IsCommentTypeTap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Comment;
 

--- a/src/Taps/Comment/IsCommentTypeTap.php
+++ b/src/Taps/Comment/IsCommentTypeTap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Comment;
 

--- a/src/Taps/Comment/IsUserTap.php
+++ b/src/Taps/Comment/IsUserTap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Comment;
 

--- a/src/Taps/Comment/IsUserTap.php
+++ b/src/Taps/Comment/IsUserTap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Comment;
 

--- a/src/Taps/Option/IsAutoloadTap.php
+++ b/src/Taps/Option/IsAutoloadTap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Option;
 

--- a/src/Taps/Option/IsAutoloadTap.php
+++ b/src/Taps/Option/IsAutoloadTap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Option;
 

--- a/src/Taps/Post/IsAuthorTap.php
+++ b/src/Taps/Post/IsAuthorTap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Post;
 

--- a/src/Taps/Post/IsAuthorTap.php
+++ b/src/Taps/Post/IsAuthorTap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Post;
 

--- a/src/Taps/Post/IsPingStatusTap.php
+++ b/src/Taps/Post/IsPingStatusTap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Post;
 

--- a/src/Taps/Post/IsPingStatusTap.php
+++ b/src/Taps/Post/IsPingStatusTap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Post;
 

--- a/src/Taps/Post/IsPostTypeTap.php
+++ b/src/Taps/Post/IsPostTypeTap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Post;
 

--- a/src/Taps/Post/IsPostTypeTap.php
+++ b/src/Taps/Post/IsPostTypeTap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Post;
 

--- a/src/Taps/Post/IsStatusTap.php
+++ b/src/Taps/Post/IsStatusTap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Post;
 

--- a/src/Taps/Post/IsStatusTap.php
+++ b/src/Taps/Post/IsStatusTap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Taps\Post;
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 if (!function_exists('event')) {
     /**
      * Dispatch an event and call the listeners.

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,10 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
-
+declare(strict_types=1);
 if (!function_exists('event')) {
     /**
      * Dispatch an event and call the listeners.

--- a/tests/Unit/Bootstrap.php
+++ b/tests/Unit/Bootstrap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit;
 

--- a/tests/Unit/Bootstrap.php
+++ b/tests/Unit/Bootstrap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit;
 

--- a/tests/Unit/Concerns/HasMetasTest.php
+++ b/tests/Unit/Concerns/HasMetasTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Concerns;
 

--- a/tests/Unit/Concerns/HasMetasTest.php
+++ b/tests/Unit/Concerns/HasMetasTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Concerns;
 

--- a/tests/Unit/Models/CommentTest.php
+++ b/tests/Unit/Models/CommentTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Models;
 

--- a/tests/Unit/Models/CommentTest.php
+++ b/tests/Unit/Models/CommentTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Models;
 

--- a/tests/Unit/Models/CustomCommentTest.php
+++ b/tests/Unit/Models/CustomCommentTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Models;
 

--- a/tests/Unit/Models/CustomCommentTest.php
+++ b/tests/Unit/Models/CustomCommentTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Models;
 

--- a/tests/Unit/Models/CustomPostTest.php
+++ b/tests/Unit/Models/CustomPostTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Models;
 

--- a/tests/Unit/Models/CustomPostTest.php
+++ b/tests/Unit/Models/CustomPostTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Models;
 

--- a/tests/Unit/Orm/DatabaseTest.php
+++ b/tests/Unit/Orm/DatabaseTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Orm;
 

--- a/tests/Unit/Orm/DatabaseTest.php
+++ b/tests/Unit/Orm/DatabaseTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Orm;
 

--- a/tests/Unit/Scopes/CustomModelTypeScopeTest.php
+++ b/tests/Unit/Scopes/CustomModelTypeScopeTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Scopes;
 

--- a/tests/Unit/Scopes/CustomModelTypeScopeTest.php
+++ b/tests/Unit/Scopes/CustomModelTypeScopeTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\Unit\Scopes;
 

--- a/tests/WordPress/Bootstrap.php
+++ b/tests/WordPress/Bootstrap.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress;
 

--- a/tests/WordPress/Bootstrap.php
+++ b/tests/WordPress/Bootstrap.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress;
 

--- a/tests/WordPress/Builders/UserBuilderTest.php
+++ b/tests/WordPress/Builders/UserBuilderTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Builders;
 

--- a/tests/WordPress/Builders/UserBuilderTest.php
+++ b/tests/WordPress/Builders/UserBuilderTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Builders;
 

--- a/tests/WordPress/Concerns/HasMetasTest.php
+++ b/tests/WordPress/Concerns/HasMetasTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Concerns;
 

--- a/tests/WordPress/Concerns/HasMetasTest.php
+++ b/tests/WordPress/Concerns/HasMetasTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Concerns;
 

--- a/tests/WordPress/Concerns/PrunableTest.php
+++ b/tests/WordPress/Concerns/PrunableTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Concerns;
 

--- a/tests/WordPress/Concerns/PrunableTest.php
+++ b/tests/WordPress/Concerns/PrunableTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Concerns;
 

--- a/tests/WordPress/Models/ArticleTest.php
+++ b/tests/WordPress/Models/ArticleTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/ArticleTest.php
+++ b/tests/WordPress/Models/ArticleTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/AttachmentTest.php
+++ b/tests/WordPress/Models/AttachmentTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/AttachmentTest.php
+++ b/tests/WordPress/Models/AttachmentTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/CommentTest.php
+++ b/tests/WordPress/Models/CommentTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/CommentTest.php
+++ b/tests/WordPress/Models/CommentTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/CustomCommentTest.php
+++ b/tests/WordPress/Models/CustomCommentTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/CustomCommentTest.php
+++ b/tests/WordPress/Models/CustomCommentTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/CustomPostTest.php
+++ b/tests/WordPress/Models/CustomPostTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/CustomPostTest.php
+++ b/tests/WordPress/Models/CustomPostTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/OptionTest.php
+++ b/tests/WordPress/Models/OptionTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/OptionTest.php
+++ b/tests/WordPress/Models/OptionTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/PageTest.php
+++ b/tests/WordPress/Models/PageTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/PageTest.php
+++ b/tests/WordPress/Models/PageTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/PostTest.php
+++ b/tests/WordPress/Models/PostTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/PostTest.php
+++ b/tests/WordPress/Models/PostTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/UserTest.php
+++ b/tests/WordPress/Models/UserTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Models/UserTest.php
+++ b/tests/WordPress/Models/UserTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Models;
 

--- a/tests/WordPress/Orm/AbstractModelTest.php
+++ b/tests/WordPress/Orm/AbstractModelTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm;
 

--- a/tests/WordPress/Orm/AbstractModelTest.php
+++ b/tests/WordPress/Orm/AbstractModelTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm;
 

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm;
 

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm;
 

--- a/tests/WordPress/Orm/DatabaseTest.php
+++ b/tests/WordPress/Orm/DatabaseTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm;
 

--- a/tests/WordPress/Orm/DatabaseTest.php
+++ b/tests/WordPress/Orm/DatabaseTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm;
 

--- a/tests/WordPress/Orm/DatabaseTransactionTest.php
+++ b/tests/WordPress/Orm/DatabaseTransactionTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm;
 

--- a/tests/WordPress/Orm/DatabaseTransactionTest.php
+++ b/tests/WordPress/Orm/DatabaseTransactionTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm;
 

--- a/tests/WordPress/Orm/Schemas/WordPressBuilderTest.php
+++ b/tests/WordPress/Orm/Schemas/WordPressBuilderTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm\Schemas;
 

--- a/tests/WordPress/Orm/Schemas/WordPressBuilderTest.php
+++ b/tests/WordPress/Orm/Schemas/WordPressBuilderTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Orm\Schemas;
 

--- a/tests/WordPress/Taps/Attachment/IsMimeTypeTapTest.php
+++ b/tests/WordPress/Taps/Attachment/IsMimeTypeTapTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Attachment;
 

--- a/tests/WordPress/Taps/Attachment/IsMimeTypeTapTest.php
+++ b/tests/WordPress/Taps/Attachment/IsMimeTypeTapTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Attachment;
 

--- a/tests/WordPress/Taps/Comment/IsApprovedTapTest.php
+++ b/tests/WordPress/Taps/Comment/IsApprovedTapTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Comment;
 

--- a/tests/WordPress/Taps/Comment/IsApprovedTapTest.php
+++ b/tests/WordPress/Taps/Comment/IsApprovedTapTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Comment;
 

--- a/tests/WordPress/Taps/Comment/IsCommentTypeTapTest.php
+++ b/tests/WordPress/Taps/Comment/IsCommentTypeTapTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Comment;
 

--- a/tests/WordPress/Taps/Comment/IsCommentTypeTapTest.php
+++ b/tests/WordPress/Taps/Comment/IsCommentTypeTapTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Comment;
 

--- a/tests/WordPress/Taps/Comment/IsUserTapTest.php
+++ b/tests/WordPress/Taps/Comment/IsUserTapTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Comment;
 

--- a/tests/WordPress/Taps/Comment/IsUserTapTest.php
+++ b/tests/WordPress/Taps/Comment/IsUserTapTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Comment;
 

--- a/tests/WordPress/Taps/Post/IsAuthorTapTest.php
+++ b/tests/WordPress/Taps/Post/IsAuthorTapTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Post;
 

--- a/tests/WordPress/Taps/Post/IsAuthorTapTest.php
+++ b/tests/WordPress/Taps/Post/IsAuthorTapTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Post;
 

--- a/tests/WordPress/Taps/Post/IsPingStatusTapTest.php
+++ b/tests/WordPress/Taps/Post/IsPingStatusTapTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Post;
 

--- a/tests/WordPress/Taps/Post/IsPingStatusTapTest.php
+++ b/tests/WordPress/Taps/Post/IsPingStatusTapTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Post;
 

--- a/tests/WordPress/Taps/Post/IsPostTypeTapTest.php
+++ b/tests/WordPress/Taps/Post/IsPostTypeTapTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Post;
 

--- a/tests/WordPress/Taps/Post/IsPostTypeTapTest.php
+++ b/tests/WordPress/Taps/Post/IsPostTypeTapTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Post;
 

--- a/tests/WordPress/Taps/Post/IsStatusTapTest.php
+++ b/tests/WordPress/Taps/Post/IsStatusTapTest.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Post;
 

--- a/tests/WordPress/Taps/Post/IsStatusTapTest.php
+++ b/tests/WordPress/Taps/Post/IsStatusTapTest.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress\Taps\Post;
 

--- a/tests/WordPress/TestCase.php
+++ b/tests/WordPress/TestCase.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress;
 

--- a/tests/WordPress/TestCase.php
+++ b/tests/WordPress/TestCase.php
@@ -2,9 +2,8 @@
 /**
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
- *
- * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
  */
+declare(strict_types=1);
 
 namespace Dbout\WpOrm\Tests\WordPress;
 


### PR DESCRIPTION
  **Summary**                                                   
         
  - Lock `rector/rector` version to ~2.4.0 to prevent new rules from breaking CI on minor updates
  - Add `fix:rector` composer script to apply Rector fixes (vendor/bin/rector process src)     
  - Update header license

 **Context**

Rector does not follow strict semver for its rules: each minor version can introduce new rules that flag existing code, causing unexpected CI failures. Pinning to ~2.4.0 ensures only patch-level updates are pulled automatically. Version bumps can be done manually when ready to address new rules.