### PR TITLE
🚨 Security: replace esc_sql by $wpdb->prepare() in Database::bindParams

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,14 +38,13 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5",
     "rector/rector": "~2.4.0",
     "phpstan/extension-installer": "^1.4",
     "szepeviktor/phpstan-wordpress": "^2.0",
     "friendsofphp/php-cs-fixer": "^3.68",
     "phpstan/phpstan": "^2.0",
-    "roots/wordpress": "^6.8",
-    "yoast/phpunit-polyfills": "^3.0"
+    "roots/wordpress": "^6.8"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -38,13 +38,14 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^12.5",
+    "phpunit/phpunit": "^9.0",
     "rector/rector": "~2.4.0",
     "phpstan/extension-installer": "^1.4",
     "szepeviktor/phpstan-wordpress": "^2.0",
     "friendsofphp/php-cs-fixer": "^3.68",
     "phpstan/phpstan": "^2.0",
-    "roots/wordpress": "^6.8"
+    "roots/wordpress": "^6.8",
+    "yoast/phpunit-polyfills": "^3.0"
   },
   "config": {
     "allow-plugins": {

--- a/src/Orm/Database.php
+++ b/src/Orm/Database.php
@@ -131,7 +131,7 @@ class Database extends Connection
     }
 
     /**
-     * A hacky way to emulate bind parameters into SQL query.
+     * Bind parameters into SQL query using $wpdb->prepare().
      *
      * @param string|null $query
      * @param array $bindings
@@ -139,24 +139,38 @@ class Database extends Connection
      */
     private function bindParams(?string $query, array $bindings): string
     {
-        $query = \str_replace('"', '`', (string)$query);
+        $query = (string) $query;
         $bindings = $this->prepareBindings($bindings);
         if ($bindings === []) {
             return $query;
         }
 
-        $bindings = \array_map(function ($replace) {
-            if (\is_string($replace)) {
-                $replace = "'" . esc_sql($replace) . "'";
-            } elseif ($replace === null) {
-                $replace = "null";
+        $parts = \explode('?', \str_replace('%', '%%', $query));
+        $sql = $parts[0];
+        $prepareBindings = [];
+
+        foreach ($bindings as $index => $value) {
+            if ($value === null) {
+                $sql .= 'null';
+            } elseif (\is_int($value)) {
+                $sql .= '%d';
+                $prepareBindings[] = $value;
+            } elseif (\is_float($value)) {
+                $sql .= '%f';
+                $prepareBindings[] = $value;
+            } else {
+                $sql .= '%s';
+                $prepareBindings[] = $value;
             }
 
-            return $replace;
-        }, $bindings);
+            $sql .= $parts[$index + 1] ?? '';
+        }
 
-        $query = \str_replace(['%', '?'], ['%%', '%s'], $query);
-        return \vsprintf($query, $bindings);
+        if ($prepareBindings === []) {
+            return $sql;
+        }
+
+        return $this->db->prepare($sql, $prepareBindings);
     }
 
     /**


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                                  
                                                                                                                                                                                                                           
  - Refactor `Database::bindParams()` to use `$wpdb->prepare()` instead of manual esc_sql() + vsprintf() binding                                                                                                               
  - Remove the str_replace('"', '')` hack that globally converted double quotes to backticks                                                                                                                               
  - Use proper format specifiers (%d for int, %f for float, %s for string) to match PHP types                                                                                                                              
                                                                                                                                                                                                                           **Why**                                                                                                                                                                                                                      
                                                                                                                                                                                                                           
  The previous implementation had several security and reliability concerns:                                                                                                                                               
  - esc_sql() + vsprintf() reimplemented parameter binding instead of using WordPress-standard $wpdb->prepare()                                                                                                          
  - The global " → ` replacement could corrupt string values containing double quotes                                                                                                                                      
  - The % → %% conversion could interfere with values legitimately containing percent characters                                                                                                                         
                                                                                                                                                                                                                          `$wpdb->prepare()` handles all these cases correctly and receives security audits from the WordPress core team. 

Fix: #153 