### PR TITLE
🥷 Database::$transactionCount is protected

### DIFF
--- a/src/Orm/Database.php
+++ b/src/Orm/Database.php
@@ -28,7 +28,7 @@ class Database extends Connection
      * Count of active transactions.
      * @var int
      */
-    public int $transactionCount = 0;
+    protected int $transactionCount = 0;
 
     /**
      * @var Database|null

--- a/tests/WordPress/Orm/DatabaseTransactionTest.php
+++ b/tests/WordPress/Orm/DatabaseTransactionTest.php
@@ -173,7 +173,7 @@ class DatabaseTransactionTest extends TestCase
         $firstQuery = reset($query)[0] ?? '';
         $lastQuery = end($query)[0] ?? '';
         $this->assertEquals('START TRANSACTION;', $firstQuery);
-        $this->assertEquals(0, $this->db->transactionCount);
+        $this->assertEquals(0, $this->db->transactionLevel());
 
         if ($mode === 'commit') {
             $this->assertEquals('COMMIT;', $lastQuery);


### PR DESCRIPTION
The property is accessible with `transactionLevel()`