### PR TITLE
🐞 Fix: use belongsTo instead of hasOne for Post and Comment relations

### DIFF
--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -9,7 +9,7 @@ namespace Dbout\WpOrm\Models;
 use Carbon\Carbon;
 use Dbout\WpOrm\Builders\CommentBuilder;
 use Dbout\WpOrm\Orm\AbstractModel;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @method Comment setCommentAuthor(?string $author)
@@ -89,27 +89,27 @@ class Comment extends AbstractModel
     ];
 
     /**
-     * @return HasOne
+     * @return BelongsTo
      */
-    public function user(): HasOne
+    public function user(): BelongsTo
     {
-        return $this->hasOne(User::class, User::USER_ID, self::USER_ID);
+        return $this->belongsTo(User::class, self::USER_ID, User::USER_ID);
     }
 
     /**
-     * @return HasOne
+     * @return BelongsTo
      */
-    public function post(): HasOne
+    public function post(): BelongsTo
     {
-        return $this->hasOne(Post::class, Post::POST_ID, self::POST_ID);
+        return $this->belongsTo(Post::class, self::POST_ID, Post::POST_ID);
     }
 
     /**
-     * @return HasOne
+     * @return BelongsTo
      */
-    public function parent(): HasOne
+    public function parent(): BelongsTo
     {
-        return $this->hasOne(Comment::class, Comment::COMMENT_ID, self::PARENT);
+        return $this->belongsTo(Comment::class, self::PARENT, Comment::COMMENT_ID);
     }
 
     /**

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -13,8 +13,8 @@ use Dbout\WpOrm\Concerns\HasMetas;
 use Dbout\WpOrm\MetaMappingConfig;
 use Dbout\WpOrm\Models\Meta\PostMeta;
 use Dbout\WpOrm\Orm\AbstractModel;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Collection;
 
 /**
@@ -122,11 +122,11 @@ class Post extends AbstractModel implements WithMetaModelInterface
     protected $table = 'posts';
 
     /**
-     * @return HasOne
+     * @return BelongsTo
      */
-    public function author(): HasOne
+    public function author(): BelongsTo
     {
-        return $this->hasOne(User::class, User::USER_ID, self::AUTHOR);
+        return $this->belongsTo(User::class, self::AUTHOR, User::USER_ID);
     }
 
     /**
@@ -138,11 +138,11 @@ class Post extends AbstractModel implements WithMetaModelInterface
     }
 
     /**
-     * @return HasOne
+     * @return BelongsTo
      */
-    public function parent(): HasOne
+    public function parent(): BelongsTo
     {
-        return $this->hasOne(Post::class, Post::POST_ID, self::PARENT);
+        return $this->belongsTo(Post::class, self::PARENT, Post::POST_ID);
     }
 
     /**

--- a/tests/WordPress/Models/CommentTest.php
+++ b/tests/WordPress/Models/CommentTest.php
@@ -34,7 +34,7 @@ class CommentTest extends TestCase
 
         $reloadComment = Comment::find($comment->getId());
         $user = $reloadComment->user;
-        $this->assertLastQueryHasOneRelation('users', 'ID', $userId);
+        $this->assertLastQueryBelongsToRelation('users', 'ID', $userId);
 
         $this->assertInstanceOf(User::class, $user);
         $this->assertEquals($userId, $user->getId());
@@ -62,7 +62,7 @@ class CommentTest extends TestCase
 
         $reloadComment = Comment::find($comment->getId());
         $post = $reloadComment->post;
-        $this->assertLastQueryHasOneRelation('posts', 'ID', $postId);
+        $this->assertLastQueryBelongsToRelation('posts', 'ID', $postId);
 
         $this->assertInstanceOf(Post::class, $post);
         $this->assertEquals($postId, $post->getId());
@@ -89,7 +89,7 @@ class CommentTest extends TestCase
 
         $reloadComment = Comment::find($comment->getId());
         $parent = $reloadComment->parent;
-        $this->assertLastQueryHasOneRelation('comments', 'comment_ID', $objectId);
+        $this->assertLastQueryBelongsToRelation('comments', 'comment_ID', $objectId);
 
         $this->assertInstanceOf(Comment::class, $parent);
         $this->assertEquals($objectId, $parent->getId());

--- a/tests/WordPress/Models/PostTest.php
+++ b/tests/WordPress/Models/PostTest.php
@@ -105,7 +105,7 @@ class PostTest extends TestCase
 
         $newObject = Post::find($object->getId());
         $parent = $newObject->parent;
-        $this->assertLastQueryHasOneRelation('posts', 'ID', $objectId);
+        $this->assertLastQueryBelongsToRelation('posts', 'ID', $objectId);
 
         $this->assertInstanceOf(Post::class, $parent);
         $this->assertEquals($objectId, $parent->getId());
@@ -134,7 +134,7 @@ class PostTest extends TestCase
 
         $newObject = Post::find($object->getId());
         $author = $newObject->author;
-        $this->assertLastQueryHasOneRelation('users', 'ID', $userId);
+        $this->assertLastQueryBelongsToRelation('users', 'ID', $userId);
         $this->assertInstanceOf(User::class, $author);
         $this->assertEquals($userId, $author->getId());
     }

--- a/tests/WordPress/TestCase.php
+++ b/tests/WordPress/TestCase.php
@@ -127,6 +127,25 @@ abstract class TestCase extends \WP_UnitTestCase
     }
 
     /**
+     * @param string $table
+     * @param string $pkColumn
+     * @param string $pkValue
+     * @return void
+     */
+    public function assertLastQueryBelongsToRelation(string $table, string $pkColumn, string $pkValue): void
+    {
+        $table = sprintf('#TABLE_PREFIX#%s', $table);
+        $this->assertLastQueryEquals(
+            sprintf(
+                "select `%1\$s`.* from `%1\$s` where `%1\$s`.`%2\$s` = %3\$s limit 1",
+                $table,
+                $pkColumn,
+                $pkValue
+            )
+        );
+    }
+
+    /**
      * @param string $query
      * @param string $message
      * @return void


### PR DESCRIPTION
**Summary**

- Replace `hasOne()` by `belongsTo()` for `Post::author()`, `Post::parent()`, `Comment::user()`, `Comment::post()` and `Comment::parent()` relations
                                                                                                                                                                                                                                    
**Why**

These relations use a foreign key on the current model's table (e.g. posts.post_author → users.ID), which is the definition of belongsTo. Using hasOne worked by coincidence (same SQL generated with explicit arguments) but is semantically incorrect and prevents using Eloquent features like associate() / dissociate().

**Breaking Change**

The return type of the following relation methods changed from `HasOne` to `BelongsTo`:                                                                                                                                           
   
  | Model | Method | Before | After |                                                                                                                                                                                               
  |-------|--------|--------|-------|                       
  | `Post` | `author()` | `HasOne` | `BelongsTo` |
  | `Post` | `parent()` | `HasOne` | `BelongsTo` |                                                                                                                                                                                  
  | `Comment` | `user()` | `HasOne` | `BelongsTo` |
  | `Comment` | `post()` | `HasOne` | `BelongsTo` |                                                                                                                                                                                 
  | `Comment` | `parent()` | `HasOne` | `BelongsTo` |       
                                                                                                                                                                                                                                    
  **Not impacted:** accessing relations via the magic property (`$post->author`, `$comment->post`, etc.) continues to work identically.                                                                                             
   
  **Impacted:** code that type-hints `HasOne` or calls `HasOne`-specific methods on these relations. Replace `HasOne` by `BelongsTo` in your type-hints.  

