### PR TITLE
🐞 Fix: use belongsTo instead of hasOne for PostMeta, UserMeta, SiteMeta and Signup relations

### DIFF
--- a/src/Models/Meta/PostMeta.php
+++ b/src/Models/Meta/PostMeta.php
@@ -7,7 +7,7 @@
 namespace Dbout\WpOrm\Models\Meta;
 
 use Dbout\WpOrm\Models\Post;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property-read Post|null $post
@@ -28,10 +28,10 @@ class PostMeta extends AbstractMeta
     protected $primaryKey = self::META_ID;
 
     /**
-     * @return HasOne
+     * @return BelongsTo
      */
-    public function post(): HasOne
+    public function post(): BelongsTo
     {
-        return $this->hasOne(Post::class, Post::POST_ID, self::POST_ID);
+        return $this->belongsTo(Post::class, self::POST_ID, Post::POST_ID);
     }
 }

--- a/src/Models/Meta/UserMeta.php
+++ b/src/Models/Meta/UserMeta.php
@@ -7,7 +7,7 @@
 namespace Dbout\WpOrm\Models\Meta;
 
 use Dbout\WpOrm\Models\User;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property-read User|null $user
@@ -33,10 +33,10 @@ class UserMeta extends AbstractMeta
     protected bool $useBasePrefix = true;
 
     /**
-     * @return HasOne
+     * @return BelongsTo
      */
-    public function user(): HasOne
+    public function user(): BelongsTo
     {
-        return $this->hasOne(User::class, User::USER_ID, self::USER_ID);
+        return $this->belongsTo(User::class, self::USER_ID, User::USER_ID);
     }
 }

--- a/src/Models/Multisite/Signup.php
+++ b/src/Models/Multisite/Signup.php
@@ -9,7 +9,7 @@ namespace Dbout\WpOrm\Models\Multisite;
 use Carbon\Carbon;
 use Dbout\WpOrm\Models\User;
 use Dbout\WpOrm\Orm\AbstractModel;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @method string getDomain()
@@ -64,8 +64,8 @@ class Signup extends AbstractModel
         self::ACTIVE => 'bool',
     ];
 
-    public function user(): HasOne
+    public function user(): BelongsTo
     {
-        return $this->hasOne(User::class, User::EMAIL, self::USER_EMAIL);
+        return $this->belongsTo(User::class, self::USER_EMAIL, User::EMAIL);
     }
 }

--- a/src/Models/Multisite/SiteMeta.php
+++ b/src/Models/Multisite/SiteMeta.php
@@ -7,7 +7,7 @@
 namespace Dbout\WpOrm\Models\Multisite;
 
 use Dbout\WpOrm\Models\Meta\AbstractMeta;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @method int getSiteId()
@@ -30,8 +30,8 @@ class SiteMeta extends AbstractMeta
 
     protected $primaryKey = self::META_ID;
 
-    public function site(): HasOne
+    public function site(): BelongsTo
     {
-        return $this->hasOne(Site::class, Site::ID, self::SITE_ID);
+        return $this->belongsTo(Site::class, self::SITE_ID, Site::ID);
     }
 }


### PR DESCRIPTION
**Summary**

- Replace `hasOne()` by `belongsTo()` for `PostMeta::post()`, `UserMeta::user()`, `SiteMeta::site()` and `Signup::user()` relations

**Why**                                                                                                                                                                                                                            
                                                                                                                                                                                                                                    
  Same fix as #157 — these relations use a foreign key on the **current** model's table (e.g. `postmeta.post_id` → `posts.ID`), which is the definition of `belongsTo`. Using `hasOne` was semantically incorrect and prevented     
  using Eloquent features like `associate()` / `dissociate()`.
                                                                                                                                                                                                                                    
  **Breaking Change**                                     

  The return type of the following relation methods changed from `HasOne` to `BelongsTo`:

  | Model | Method | Before | After |
  |-------|--------|--------|-------|
  | `PostMeta` | `post()` | `HasOne` | `BelongsTo` |                                                                                                                                                                                
  | `UserMeta` | `user()` | `HasOne` | `BelongsTo` |
  | `SiteMeta` | `site()` | `HasOne` | `BelongsTo` |                                                                                                                                                                                
  | `Signup` | `user()` | `HasOne` | `BelongsTo` |                                                                                                                                                                                  
   
  **Not impacted:** accessing relations via the magic property (`$postMeta->post`, etc.) continues to work identically.                                                                                                             
                                                            
  **Impacted:** code that type-hints `HasOne` or calls `HasOne`-specific methods on these relations. Replace `HasOne` by `BelongsTo` in your type-hints.