### PR TITLE
🐞 Fix: add 'real' to primitiveMetaCastTypes and improve HasMetas unit tests

### DIFF
--- a/src/Concerns/HasMetas.php
+++ b/src/Concerns/HasMetas.php
@@ -39,6 +39,7 @@ trait HasMetas
         'datetime',
         'double',
         'float',
+        'real',
         'immutable_date',
         'int',
         'integer',

--- a/tests/Unit/Concerns/HasMetasTest.php
+++ b/tests/Unit/Concerns/HasMetasTest.php
@@ -9,6 +9,7 @@ namespace Dbout\WpOrm\Tests\Unit\Concerns;
 use Dbout\WpOrm\Concerns\HasMetas;
 use Dbout\WpOrm\Models\Post;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversTrait(HasMetas::class)]
@@ -79,5 +80,96 @@ class HasMetasTest extends TestCase
             'custom-meta' => 'int',
             'my-meta' => 'string',
         ], $model->getMetaCasts());
+    }
+
+    /**
+     * @param string $castType
+     * @param mixed $value
+     * @param mixed $expected
+     * @return void
+     */
+    #[DataProvider('castMetaProvider')]
+    public function testCastMeta(string $castType, mixed $value, mixed $expected): void
+    {
+        $model = new class () extends Post {
+            protected array $metaCasts = [];
+
+            public function setCastType(string $type): void
+            {
+                $this->metaCasts = ['test_key' => $type];
+            }
+
+            public function callCastMeta(string $key, mixed $value): mixed
+            {
+                return $this->castMeta($key, $value);
+            }
+        };
+
+        $model->setCastType($castType);
+        $this->assertSame($expected, $model->callCastMeta('test_key', $value));
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed, mixed}>
+     */
+    public static function castMetaProvider(): iterable
+    {
+        yield 'int cast' => ['int', '42', 42];
+        yield 'integer cast' => ['integer', '10', 10];
+        yield 'float cast' => ['float', '3.14', 3.14];
+        yield 'double cast' => ['double', '2.71', 2.71];
+        yield 'real cast' => ['real', '1.5', 1.5];
+        yield 'string cast' => ['string', 123, '123'];
+        yield 'bool true cast' => ['bool', '1', true];
+        yield 'bool false cast' => ['bool', '0', false];
+        yield 'boolean cast' => ['boolean', '1', true];
+    }
+
+    /**
+     * @param string $castType
+     * @return void
+     */
+    #[DataProvider('castMetaNullProvider')]
+    public function testCastMetaReturnsNullForNullValue(string $castType): void
+    {
+        $model = new class () extends Post {
+            protected array $metaCasts = [];
+
+            public function setCastType(string $type): void
+            {
+                $this->metaCasts = ['test_key' => $type];
+            }
+
+            public function callCastMeta(string $key, mixed $value): mixed
+            {
+                return $this->castMeta($key, $value);
+            }
+        };
+
+        $model->setCastType($castType);
+        $this->assertNull($model->callCastMeta('test_key', null));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function castMetaNullProvider(): iterable
+    {
+        yield 'int' => ['int'];
+        yield 'integer' => ['integer'];
+        yield 'float' => ['float'];
+        yield 'double' => ['double'];
+        yield 'real' => ['real'];
+        yield 'string' => ['string'];
+        yield 'bool' => ['bool'];
+        yield 'boolean' => ['boolean'];
+        yield 'array' => ['array'];
+        yield 'json' => ['json'];
+        yield 'object' => ['object'];
+        yield 'collection' => ['collection'];
+        yield 'date' => ['date'];
+        yield 'datetime' => ['datetime'];
+        yield 'immutable_date' => ['immutable_date'];
+        yield 'timestamp' => ['timestamp'];
     }
 }


### PR DESCRIPTION
**Summary** 

- Add missing `'real'` type to `$primitiveMetaCastTypes` in `HasMetas` trait
- Add unit tests for `castMeta()` covering all primitive types and null handling

**Why**

The `'real'` cast type was handled in the `castMeta()` switch statement but missing from `$primitiveMetaCastTypes`. This caused `castMeta('key', null)` to return `(float) null` → `0.0` instead of `null` for metas cast as `'real'`.