### PR TITLE
🧯 Security: harden meta join to prevent SQL injection through identifiers

### DIFF
--- a/src/Builders/AbstractWithMetaBuilder.php
+++ b/src/Builders/AbstractWithMetaBuilder.php
@@ -11,11 +11,17 @@ use Dbout\WpOrm\Exceptions\MetaNotSupportedException;
 use Dbout\WpOrm\Exceptions\WpOrmException;
 use Dbout\WpOrm\MetaMappingConfig;
 use Dbout\WpOrm\Orm\AbstractModel;
-use Dbout\WpOrm\Orm\Database;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\JoinClause;
 
 abstract class AbstractWithMetaBuilder extends AbstractBuilder
 {
+    /**
+     * Allowed pattern for any string used as a SQL identifier (table alias, column alias).
+     * Restricted to a conservative subset to prevent SQL injection through identifiers.
+     */
+    private const string IDENTIFIER_PATTERN = '/^[A-Za-z_]\w*$/';
+
     /**
      * @var array<string, string>
      */
@@ -59,7 +65,9 @@ abstract class AbstractWithMetaBuilder extends AbstractBuilder
             $alias = sprintf('%s_value', $metaKey);
         }
 
-        $column = sprintf('%s.%s AS %s', $metaKey, $this->metaConfig?->columnValue, $alias);
+        $this->assertValidIdentifier($alias, 'meta select alias');
+
+        $column = sprintf('%s.%s AS %s', $metaKey, $this->metaConfig->columnValue, $alias);
         $this->addSelect($column);
         return $this;
     }
@@ -107,6 +115,8 @@ abstract class AbstractWithMetaBuilder extends AbstractBuilder
      */
     public function joinToMeta(string $metaKey, string $joinType = 'inner'): self
     {
+        $this->assertValidIdentifier($metaKey, 'meta key');
+
         $model = $this->model;
         $joinTable = sprintf('%s AS %s', $this->metaTable, $metaKey);
 
@@ -119,20 +129,37 @@ abstract class AbstractWithMetaBuilder extends AbstractBuilder
             throw new WpOrmException('Invalid join type.');
         }
 
-        $this->$join($joinTable, function ($join) use ($metaKey, $model) {
-            /** @var \Illuminate\Database\Query\JoinClause $join */
-            $join->on(
-                sprintf('%s.%s', $metaKey, $this->metaConfig?->columnKey),
-                '=',
-                Database::getInstance()->raw(sprintf("'%s'", esc_sql($metaKey)))
-            )->on(
-                sprintf('%s.%s', $metaKey, $this->metaConfig?->foreignKey),
-                '=',
-                sprintf('%s.%s', $model->getTable(), $model->getKeyName()),
-            );
+        $this->$join($joinTable, function (JoinClause $join) use ($metaKey, $model): void {
+            $join
+                ->on(
+                    sprintf('%s.%s', $metaKey, $this->metaConfig->foreignKey),
+                    '=',
+                    sprintf('%s.%s', $model->getTable(), $model->getKeyName())
+                )
+                ->where(
+                    sprintf('%s.%s', $metaKey, $this->metaConfig->columnKey),
+                    '=',
+                    $metaKey
+                );
         });
 
         return $this;
+    }
+
+    /**
+     * Validate that a value is safe to be inlined as a SQL identifier.
+     *
+     * @throws WpOrmException
+     */
+    private function assertValidIdentifier(string $identifier, string $context): void
+    {
+        if (preg_match(self::IDENTIFIER_PATTERN, $identifier) !== 1) {
+            throw new WpOrmException(sprintf(
+                'Invalid %s "%s": only letters, digits and underscores are allowed (must start with a letter or underscore).',
+                $context,
+                $identifier
+            ));
+        }
     }
 
     /**

--- a/tests/WordPress/Builders/PostBuilderTest.php
+++ b/tests/WordPress/Builders/PostBuilderTest.php
@@ -253,4 +253,66 @@ class PostBuilderTest extends TestCase
 
         $this->assertCount(2, $results);
     }
+
+    /**
+     * @covers PostBuilder::joinToMeta
+     * @return void
+     */
+    public function testJoinToMetaRejectsInvalidIdentifier(): void
+    {
+        $this->expectException(WpOrmException::class);
+        $this->expectExceptionMessageMatches('/Invalid meta key/');
+
+        Post::query()->joinToMeta("color'; DROP TABLE wp_posts; --");
+    }
+
+    /**
+     * @covers PostBuilder::addMetaToSelect
+     * @return void
+     */
+    public function testAddMetaToSelectRejectsInvalidAlias(): void
+    {
+        $this->expectException(WpOrmException::class);
+        $this->expectExceptionMessageMatches('/Invalid meta select alias/');
+
+        Post::query()->addMetaToSelect('color', 'bad alias');
+    }
+
+    /**
+     * @covers PostBuilder::addMetaToFilter
+     * @return void
+     */
+    public function testAddMetaToFilterRejectsInvalidIdentifier(): void
+    {
+        $this->expectException(WpOrmException::class);
+        $this->expectExceptionMessageMatches('/Invalid meta key/');
+
+        Post::query()->addMetaToFilter('1invalid', 'value');
+    }
+
+    /**
+     * @covers PostBuilder::joinToMeta
+     * @return void
+     */
+    public function testJoinToMetaUsesBoundMetaKeyValue(): void
+    {
+        $post = new Post();
+        $post->setPostTitle('Bound binding test');
+        $post->setPostName('bound-binding-test');
+        $post->setPostType('post');
+        $this->assertTrue($post->save());
+        $post->setMeta('color', "red'; DROP TABLE wp_postmeta; --");
+
+        $results = Post::query()
+            ->addMetaToSelect('color')
+            ->where(Post::POST_ID, $post->getId())
+            ->get();
+
+        $first = $results->first();
+        $this->assertNotNull($first);
+        $this->assertEquals(
+            "red'; DROP TABLE wp_postmeta; --",
+            $first->getAttribute('color_value')
+        );
+    }
 }


### PR DESCRIPTION
 **Summary**

- Replace `Database::getInstance()->raw(esc_sql($metaKey))` in `AbstractWithMetaBuilder::joinToMeta()` with a proper bound parameter via `JoinClause::where()`, so the meta key value is now passed through `wpdb::prepare()` instead of  
  being inlined as a SQL literal.
- Add a strict identifier validator `(^[A-Za-z_][A-Za-z0-9_]*$)` and apply it to every value used as a SQL identifier — joined-table alias in `joinToMeta()` and column alias in `addMetaToSelect()`. Invalid input now throws `WpOrmException` instead of being silently inlined.
- Drop the now-unused Database dependency from the builder.
                                                                                                                                                                                                                                    
**Why**
                                                                                                                                                                                                                                    
`$metaKey` was previously interpolated into the SQL as both a table alias and a column prefix without any sanitization, while only the literal value side was passed through `esc_sql()`. Any caller forwarding untrusted input to  these methods was exposed to SQL injection.

**Backward compatibility**                                                                                                                                                                                                            

Functional behavior is unchanged for conforming inputs — only the SQL form changes (? placeholder instead of an inline literal). Calls passing non-conforming identifiers (spaces, dots, dashes, etc.) now raise a clear `WpOrmException`.

⚠️ BREAKING CHANGES                                                                                                                                                                                                               

This PR introduces two breaking changes. Targeted at v5, must be called out in the v5 release notes.

1. Stricter input validation on `joinToMeta()`, `addMetaToSelect()`, `addMetaToFilter()`                                                                                                                                                
                  
  Meta keys and column aliases must now match `^[A-Za-z_][A-Za-z0-9_]*$`. Any value containing dashes, dots, spaces or other special characters now throws `Wp`OrmException instead of being silently inlined.                          
                  
  In practice this matches the format of all WordPress core meta keys and the vast majority of plugin meta keys (_thumbnail_id, _edit_lock, color, etc.). Callers using exotic meta keys must normalize them.                       
                  
  2. Generated SQL form has changed                                                                                                                                                                                                 
                  
  The meta key filter inside the join clause is now emitted as a bound ? placeholder instead of an inline literal:                                                                                                                  

```
Before
  ... ON joined.meta_key = 'color' AND joined.post_id = posts.ID

After
... ON joined.post_id = posts.ID AND joined.meta_key = ?
```

Any downstream test asserting on the exact wpdb->last_query string for a query that uses joinToMeta / addMetaToSelect / addMetaToFilter must be updated.