### PR TITLE
📘 Fix wrong @method insert annotation on AbstractModel

### DIFF
--- a/src/Orm/AbstractModel.php
+++ b/src/Orm/AbstractModel.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Model;
  * @method static static|null find(int|string $objectId) Retrieve a model by its primary key.
  * @method static void truncate() Delete all the model's associated database records, operation will also reset any auto-incrementing IDs on the model's associated table.
  * @method static \Illuminate\Database\Eloquent\Builder<static> where($column, $operator = null, $value = null, $boolean = 'and') Add a basic where clause to the query.
- * @method static bool insert($query, $bindings = []) Run an insert statement against the database.
+ * @method static bool insert(array $values) Insert new records into the database.
  */
 abstract class AbstractModel extends Model
 {


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                                     
                                                                                                                                                                                                                                  
  The `@method static bool insert($query, $bindings = [])` annotation on `AbstractModel` mistakenly described `Connection::insert()` instead of the actual call path. When you call `Post::insert([...])`, the call goes through            
  `Model::__callStatic` → `query()->insert($values)` → `Illuminate\Database\Query\Builder::insert(array $values): bool`. The signature is a single array argument, not ($query, $bindings).

**References**                                                                                                                                                                                                                        
                                                                                                                                                                                                                                  
  - Laravel docs — Insert Statements: https://laravel.com/docs/12.x/queries#insert-statements                                                                                                                                       
  - `Illuminate\Database\Query\Builder::insert(array $values): bool`