### PR TITLE
✂️ Deprecate AbstractMeta::getKey() in favor of getMetaKey()

### DIFF
--- a/src/Models/Meta/AbstractMeta.php
+++ b/src/Models/Meta/AbstractMeta.php
@@ -10,8 +10,8 @@ use Dbout\WpOrm\Orm\AbstractModel;
 
 abstract class AbstractMeta extends AbstractModel
 {
-    final public const META_KEY = 'meta_key';
-    final public const META_VALUE = 'meta_value';
+    final public const string META_KEY = 'meta_key';
+    final public const string META_VALUE = 'meta_value';
 
     /**
      * Disable created_at and updated_at
@@ -28,18 +28,43 @@ abstract class AbstractMeta extends AbstractModel
     ];
 
     /**
+     * @deprecated Use {@see self::getMetaKey()} instead. This method shadows
+     *             {@see \Illuminate\Database\Eloquent\Model::getKey()} which is expected
+     *             to return the primary key value. Will be removed in the next major version.
      * @return string
      */
     public function getKey(): string
+    {
+        return $this->getMetaKey();
+    }
+
+    /**
+     * @deprecated Use {@see self::setMetaKey()} instead. Will be removed in the next major version.
+     * @param string $key
+     * @return $this
+     */
+    public function setKey(string $key): self
+    {
+        return $this->setMetaKey($key);
+    }
+
+    /**
+     * Get the meta key.
+     *
+     * @return string
+     */
+    public function getMetaKey(): string
     {
         return $this->getAttribute(self::META_KEY);
     }
 
     /**
+     * Set the meta key.
+     *
      * @param string $key
      * @return $this
      */
-    public function setKey(string $key): self
+    public function setMetaKey(string $key): self
     {
         $this->setAttribute(self::META_KEY, $key);
         return $this;

--- a/tests/WordPress/Concerns/HasMetasTest.php
+++ b/tests/WordPress/Concerns/HasMetasTest.php
@@ -35,7 +35,52 @@ class HasMetasTest extends TestCase
         $this->assertEquals($createMeta->getId(), $meta->getId());
         $this->assertEquals($createMeta->getValue(), $meta->getValue());
         $this->assertEquals('Norman FOSTER', $meta->getValue());
+        $this->assertEquals('author', $meta->getMetaKey());
+    }
+
+    /**
+     * @return void
+     * @covers AbstractMeta::getMetaKey
+     * @covers AbstractMeta::setMetaKey
+     * @uses Post
+     */
+    public function testGetAndSetMetaKey(): void
+    {
+        $model = new Post();
+        $model->setPostTitle(__FUNCTION__);
+        $model->save();
+        $model->setMeta('author', 'Norman FOSTER');
+
+        $meta = $model->getMeta('author');
+        $this->assertInstanceOf(AbstractMeta::class, $meta);
+        $this->assertEquals('author', $meta->getMetaKey());
+
+        $meta->setMetaKey('renamed_author');
+        $this->assertEquals('renamed_author', $meta->getMetaKey());
+    }
+
+    /**
+     * @return void
+     * @covers AbstractMeta::getKey
+     * @covers AbstractMeta::setKey
+     * @uses Post
+     */
+    public function testDeprecatedGetAndSetKeyStillWork(): void
+    {
+        $model = new Post();
+        $model->setPostTitle(__FUNCTION__);
+        $model->save();
+        $model->setMeta('author', 'Norman FOSTER');
+
+        $meta = $model->getMeta('author');
+        $this->assertInstanceOf(AbstractMeta::class, $meta);
+
+        // Deprecated API must keep returning the meta key for BC.
         $this->assertEquals('author', $meta->getKey());
+
+        $meta->setKey('renamed_author');
+        $this->assertEquals('renamed_author', $meta->getKey());
+        $this->assertEquals('renamed_author', $meta->getMetaKey());
     }
 
     /**


### PR DESCRIPTION
**Summary**

`AbstractMeta::getKey()` shadowed `Illuminate\Database\Eloquent\Model::getKey()`, which is expected to return the model's primary key value. Many Eloquent internals rely on `getKey()` (collection keying, eager loading hash maps, relation matching), so overriding it to return the meta_key column could silently break collections of meta models.

This PR introduces a clearly named replacement and deprecates the conflicting methods without breaking existing callers.

**Backward compatibility**                                                                                                                                                       
                                                                                                                                                                                                                                    
Non-breaking. `getKey()` and `setKey()` keep their behavior and are flagged @deprecated so IDEs / static analyzers warn callers. Scheduled for removal in the next major version.