### PR TITLE
📏 Support decimal and custom_datetime casts in HasMetas

### DIFF
--- a/src/Concerns/HasMetas.php
+++ b/src/Concerns/HasMetas.php
@@ -35,12 +35,16 @@ trait HasMetas
         'bool',
         'boolean',
         'collection',
+        'custom_datetime',
         'date',
         'datetime',
+        'decimal',
         'double',
         'float',
         'real',
+        'immutable_custom_datetime',
         'immutable_date',
+        'immutable_datetime',
         'int',
         'integer',
         'json',
@@ -236,6 +240,8 @@ trait HasMetas
             case 'float':
             case 'double':
                 return (float)$value;
+            case 'decimal':
+                return $this->asDecimal($value, (int)(explode(':', (string)$this->getMetaCasts()[$key], 2)[1] ?? 0));
             case 'string':
                 return (string)$value;
             case 'bool':
@@ -251,9 +257,13 @@ trait HasMetas
             case 'date':
                 return $this->asDate($value);
             case 'datetime':
+            case 'custom_datetime':
                 return $this->asDateTime($value);
             case 'immutable_date':
                 return $this->asDate($value)->toImmutable();
+            case 'immutable_datetime':
+            case 'immutable_custom_datetime':
+                return $this->asDateTime($value)->toImmutable();
             case 'timestamp':
                 return $this->asTimestamp($value);
         }

--- a/tests/Unit/Concerns/HasMetasTest.php
+++ b/tests/Unit/Concerns/HasMetasTest.php
@@ -122,6 +122,9 @@ class HasMetasTest extends TestCase
         yield 'bool true cast' => ['bool', '1', true];
         yield 'bool false cast' => ['bool', '0', false];
         yield 'boolean cast' => ['boolean', '1', true];
+        yield 'decimal cast (2 digits)' => ['decimal:2', '3.14159', '3.14'];
+        yield 'decimal cast (4 digits)' => ['decimal:4', '3.1', '3.1000'];
+        yield 'decimal cast (0 digits)' => ['decimal:0', '3.7', '4'];
     }
 
     /**
@@ -169,6 +172,10 @@ class HasMetasTest extends TestCase
         yield 'date' => ['date'];
         yield 'datetime' => ['datetime'];
         yield 'immutable_date' => ['immutable_date'];
+        yield 'immutable_datetime' => ['immutable_datetime'];
         yield 'timestamp' => ['timestamp'];
+        yield 'decimal' => ['decimal:2'];
+        yield 'custom_datetime' => ['datetime:Y-m-d'];
+        yield 'immutable_custom_datetime' => ['immutable_datetime:Y-m-d'];
     }
 }

--- a/tests/WordPress/Concerns/HasMetasTest.php
+++ b/tests/WordPress/Concerns/HasMetasTest.php
@@ -234,6 +234,60 @@ class HasMetasTest extends TestCase
      * @covers HasMetas::getMetaValue
      * @uses Post
      */
+    public function testGetMetaValueWithDecimalCast(): void
+    {
+        $object = new class () extends Post {
+            protected array $metaCasts = [
+                'price' => 'decimal:2',
+                'ratio' => 'decimal:4',
+            ];
+        };
+
+        $model = new $object();
+        $model->setPostTitle(__FUNCTION__);
+        $model->save();
+        $model->setMeta('price', '12.3456');
+        $model->setMeta('ratio', '0.5');
+
+        $this->assertSame('12.35', $model->getMetaValue('price'));
+        $this->assertSame('0.5000', $model->getMetaValue('ratio'));
+    }
+
+    /**
+     * @return void
+     * @covers HasMetas::getMetaValue
+     * @uses Post
+     */
+    public function testGetMetaValueWithCustomDatetimeCasts(): void
+    {
+        $object = new class () extends Post {
+            protected array $metaCasts = [
+                'published_at' => 'datetime:Y-m-d',
+                'archived_at' => 'immutable_datetime:Y-m-d H:i:s',
+            ];
+        };
+
+        $model = new $object();
+        $model->setPostTitle(__FUNCTION__);
+        $model->save();
+        $model->setMeta('published_at', '2024-03-12 14:25:00');
+        $model->setMeta('archived_at', '2024-04-01 09:00:00');
+
+        /** @var Carbon $published */
+        $published = $model->getMetaValue('published_at');
+        $this->assertInstanceOf(Carbon::class, $published);
+        $this->assertEquals('2024-03-12 14:25:00', $published->format('Y-m-d H:i:s'));
+
+        $archived = $model->getMetaValue('archived_at');
+        $this->assertInstanceOf(\Carbon\CarbonImmutable::class, $archived);
+        $this->assertEquals('2024-04-01 09:00:00', $archived->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @return void
+     * @covers HasMetas::getMetaValue
+     * @uses Post
+     */
     public function testGetMetaValueWithInvalidCasts(): void
     {
         $object = new class () extends Post {


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                                           

`HasMetas::castMeta()` was missing branches for `decimal`, `custom_datetime`, `immutable_datetime` and `immutable_custom_datetime`. `getMetaCastType()` already detected these formats but the actual cast switch had no matching case, so values silently fell through to the passthrough — a meta declared as `decimal:2` or `datetime:Y-m-d` was returned as a raw string with no formatting applied.

This PR brings `castMeta()` to feature parity with Eloquent's `HasAttributes::castAttribute()` for these cast types. 

**Backward compatibility**                                                                                                                                                                                                            
                                                                                                                                                                                                                                    
Non-breaking. Behavior only changes for casts that were previously accepted but silently ignored. Anyone relying on `$model->getMetaValue('price')` returning the raw string for a `decimal:2` cast will now get the formatted string — but that previous behavior was a bug, not a contract.