### PR TITLE
🧪 Improve database tests

### DIFF
--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: "Configure PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: 8.3
           tools: composer:v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit-test:
-    name: "Unit tests"
+    name: "PHPStan + unit tests"
     runs-on: ubuntu-latest
 
     steps:
@@ -22,8 +22,18 @@ jobs:
           tools: composer:v2
           coverage: xdebug
 
+      - name: "Cache Composer downloads"
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
       - name: "Install composer dependencies"
         run: composer install --prefer-dist --no-progress
+
+      - name: "Run PHPStan"
+        run: composer run phpstan
 
       - name: "Run unit tests with coverage"
         run: composer run test:unit:coverage
@@ -42,6 +52,7 @@ jobs:
   wp-test:
     name: "WordPress tests with WP ${{ matrix.wp_version }}"
     runs-on: ubuntu-latest
+    needs: unit-test
 
     strategy:
       matrix:
@@ -66,6 +77,15 @@ jobs:
           php-version: "8.3"
           tools: composer:v2
           coverage: xdebug
+
+      - name: "Cache Composer downloads"
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-wp${{ matrix.wp_version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-wp${{ matrix.wp_version }}-
+            ${{ runner.os }}-composer-
 
       - name: "Install composer dependencies"
         run: composer install --prefer-dist --no-progress
@@ -106,6 +126,7 @@ jobs:
   wp-test-multisite:
     name: "WordPress tests (multisite, WP latest)"
     runs-on: ubuntu-latest
+    needs: unit-test
 
     services:
       mysql:
@@ -125,6 +146,15 @@ jobs:
         with:
           php-version: "8.3"
           tools: composer:v2
+
+      - name: "Cache Composer downloads"
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-wplatest-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-wplatest-
+            ${{ runner.os }}-composer-
 
       - name: "Install composer dependencies"
         run: composer install --prefer-dist --no-progress

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,10 +103,54 @@ jobs:
           allow-empty: false
           parallel: true
 
+  wp-test-multisite:
+    name: "WordPress tests (multisite, WP latest)"
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:9.4
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: false
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
+
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v4
+
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          tools: composer:v2
+
+      - name: "Install composer dependencies"
+        run: composer install --prefer-dist --no-progress
+
+      - name: "Install PHPUnit v9 and WordPress latest"
+        run: |
+          composer require --dev --update-with-all-dependencies 'phpunit/phpunit:^9.0' 'yoast/phpunit-polyfills:^3.0'
+          composer require --dev --update-with-all-dependencies 'wp-phpunit/wp-phpunit:*' 'roots/wordpress:*'
+
+      - name: "Create test database"
+        run: mysql -uroot -h 127.0.0.1 -e "CREATE DATABASE IF NOT EXISTS wordpress_test;"
+
+      - name: "Run WordPress tests in multisite mode"
+        env:
+          DB_HOST: "127.0.0.1:3306"
+          DB_USER: "root"
+          MYSQL_ROOT_PASSWORD: ""
+          MYSQL_DATABASE: "wordpress_test"
+          WP_MULTISITE: "1"
+        run: composer run test:wordPress
+
   finish:
     needs:
       - unit-test
       - wp-test
+      - wp-test-multisite
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,17 +13,17 @@ jobs:
 
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: "8.3"
           tools: composer:v2
           coverage: xdebug
 
       - name: "Cache Composer downloads"
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -42,7 +42,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ github.token }}
         if: ${{ env.COVERALLS_REPO_TOKEN }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           github-token: ${{ env.COVERALLS_REPO_TOKEN }}
           flag-name: "unit"
@@ -69,17 +69,17 @@ jobs:
 
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: "8.3"
           tools: composer:v2
           coverage: xdebug
 
       - name: "Cache Composer downloads"
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-wp${{ matrix.wp_version }}-${{ hashFiles('**/composer.lock') }}
@@ -116,7 +116,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ github.token }}
         if: ${{ env.COVERALLS_REPO_TOKEN }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           github-token: ${{ env.COVERALLS_REPO_TOKEN }}
           flag-name: wp-test-$
@@ -139,16 +139,16 @@ jobs:
 
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: "8.3"
           tools: composer:v2
 
       - name: "Cache Composer downloads"
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-wplatest-${{ hashFiles('**/composer.lock') }}
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close parallel build
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           parallel-finished: true
           carryforward: "wp-test-1,wp-test-2,wp-test-3,wp-test-4,wp-test-5,wp-test-6,unit"

--- a/TESTING.md
+++ b/TESTING.md
@@ -117,6 +117,23 @@ $this->assertCount(1, $results);
 $this->assertEquals($productId, $results->first()->getId());
 ```
 
+## Test groups
+
+A handful of cross-cutting `@group` annotations are in place so subsets of
+the suite can be targeted in isolation:
+
+- `@group security` — regression tests pinning hardening (SQL injection
+  rejection in `joinToMeta` / `addMetaTo*`, bound parameter usage).
+- `@group multisite` — tests that require the suite to be booted with
+  `WP_MULTISITE=1`. Also auto-skipped when not in multisite mode via the
+  `RunsInMultisite` trait.
+
+Run a single group locally:
+
+```bash
+vendor/bin/phpunit -c phpunit-wp.xml --group security
+```
+
 ## Multisite
 
 Multisite is currently **not supported** at the ORM level (see README and

--- a/TESTING.md
+++ b/TESTING.md
@@ -117,6 +117,41 @@ $this->assertCount(1, $results);
 $this->assertEquals($productId, $results->first()->getId());
 ```
 
+## Multisite
+
+Multisite is currently **not supported** at the ORM level (see README and
+the v6 milestone). The test suite still has scaffolding so that
+multisite-only tests can be written and so the package is exercised
+against a multisite WordPress install in CI.
+
+To run the suite in multisite mode locally:
+
+```bash
+WP_MULTISITE=1 ./run-wp-tests.sh
+```
+
+A test class that should run only in multisite mode adds the
+`RunsInMultisite` trait — single-site runs auto-skip:
+
+```php
+use Dbout\WpOrm\Tests\WordPress\Support\RunsInMultisite;
+use Dbout\WpOrm\Tests\WordPress\TestCase;
+
+class MyMultisiteTest extends TestCase
+{
+    use RunsInMultisite;
+
+    public function testInsideASubsite(): void
+    {
+        $value = $this->inBlog($subsiteId, fn () => get_option('blogname'));
+        $this->assertSame('subsite', $value);
+    }
+}
+```
+
+The dedicated `wp-test-multisite` CI job runs the full WP test suite on
+WordPress latest with `WP_MULTISITE=1`.
+
 ## Important Notes
 
 - WordPress tests require **PHPUnit 9** only (WordPress limitation)

--- a/TESTING.md
+++ b/TESTING.md
@@ -93,6 +93,30 @@ The WordPress test environment is managed entirely through Composer:
 
 Each test runs inside a database transaction that is rolled back after the test completes, ensuring full isolation between tests.
 
+## Writing assertions
+
+Tests should assert on **observable behavior** (returned models, attribute values, row counts), not on the SQL string Eloquent emits. Tying tests to a specific generated SQL string makes them fragile across Eloquent grammar changes without catching real regressions.
+
+`TestCase` exposes a single SQL-introspection helper, `assertLastQueryContains(string $needle)`, intended for the rare cases where the SQL shape is itself part of the contract:
+
+- **Custom grammar overrides** — e.g. the `WordPressGrammar::wrapJsonSelector` idiom (`json_unquote(json_extract(...))`) must be pinned because it *is* what the class promises to produce.
+- **Security regression tests** — pinning that a value reaches the SQL via a binding rather than as a literal.
+
+For everything else, prefer fixture-based assertions:
+
+```php
+// ❌ Couples the test to grammar formatting
+$this->assertLastQueryContains("where `post_type` = 'product'");
+
+// ✅ Asserts the actual filtering contract
+$productId = self::factory()->post->create(['post_type' => 'product']);
+self::factory()->post->create(['post_type' => 'page']);
+
+$results = Post::query()->tap(new IsPostTypeTap('product'))->get();
+$this->assertCount(1, $results);
+$this->assertEquals($productId, $results->first()->getId());
+```
+
 ## Important Notes
 
 - WordPress tests require **PHPUnit 9** only (WordPress limitation)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,6 @@ parameters:
         - tests
     excludePaths:
         - tests/WordPress/TestCase.php
+        - tests/stubs
+    scanFiles:
+        - tests/stubs/wp-phpunit.php

--- a/tests/WordPress/Bootstrap.php
+++ b/tests/WordPress/Bootstrap.php
@@ -24,6 +24,15 @@ class Bootstrap
         }
 
         /**
+         * Enable wpdb query logging so tests can introspect $wpdb->last_query
+         * and $wpdb->queries regardless of the order in which test classes run.
+         * @see https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/#savequeries
+         */
+        if (!defined('SAVEQUERIES')) {
+            define('SAVEQUERIES', true);
+        }
+
+        /**
          * Load PHPUnit Polyfills for the WP testing suite.
          * @see https://github.com/WordPress/wordpress-develop/pull/1563/
          */

--- a/tests/WordPress/Builders/PostBuilderTest.php
+++ b/tests/WordPress/Builders/PostBuilderTest.php
@@ -192,6 +192,7 @@ class PostBuilderTest extends TestCase
     /**
      * @return void
      * @covers PostBuilder::joinToMeta
+     * @group security
      */
     public function testJoinToMetaRejectsInvalidIdentifier(): void
     {
@@ -204,6 +205,7 @@ class PostBuilderTest extends TestCase
     /**
      * @return void
      * @covers PostBuilder::addMetaToSelect
+     * @group security
      */
     public function testAddMetaToSelectRejectsInvalidAlias(): void
     {
@@ -216,6 +218,7 @@ class PostBuilderTest extends TestCase
     /**
      * @return void
      * @covers PostBuilder::addMetaToFilter
+     * @group security
      */
     public function testAddMetaToFilterRejectsInvalidIdentifier(): void
     {
@@ -228,6 +231,7 @@ class PostBuilderTest extends TestCase
     /**
      * @return void
      * @covers PostBuilder::joinToMeta
+     * @group security
      */
     public function testJoinToMetaUsesBoundMetaKeyValue(): void
     {

--- a/tests/WordPress/Builders/PostBuilderTest.php
+++ b/tests/WordPress/Builders/PostBuilderTest.php
@@ -135,7 +135,7 @@ class PostBuilderTest extends TestCase
      */
     public function testJoinToMetaDoesNotDuplicate(): void
     {
-        $post = $this->aPostWithMetas(['color' => 'blue'], 'Duplicate join test');
+        $this->aPostWithMetas(['color' => 'blue'], 'Duplicate join test');
 
         $results = Post::query()
             ->addMetaToSelect('color')

--- a/tests/WordPress/Builders/PostBuilderTest.php
+++ b/tests/WordPress/Builders/PostBuilderTest.php
@@ -9,109 +9,84 @@ namespace Dbout\WpOrm\Tests\WordPress\Builders;
 use Dbout\WpOrm\Builders\PostBuilder;
 use Dbout\WpOrm\Exceptions\WpOrmException;
 use Dbout\WpOrm\Models\Post;
+use Dbout\WpOrm\Tests\WordPress\Support\BuildsTestPost;
 use Dbout\WpOrm\Tests\WordPress\TestCase;
 
 class PostBuilderTest extends TestCase
 {
+    use BuildsTestPost;
+
     /**
+     * @param string|null $alias
+     * @param string $expectedAttribute
      * @covers PostBuilder::joinToMeta
      * @covers PostBuilder::addMetaToSelect
+     * @dataProvider providerAddMetaToSelect
      * @throws WpOrmException
      * @return void
      */
-    public function testAddMetaToSelect(): void
+    public function testAddMetaToSelect(?string $alias, string $expectedAttribute): void
     {
-        $post = new Post();
-        $post->setPostTitle('Meta select test');
-        $post->setPostName('meta-select-test');
-        $post->setPostType('post');
-        $this->assertTrue($post->save());
-        $post->setMeta('color', 'blue');
+        $post = $this->aPostWithMetas(['color' => 'blue'], 'Add meta to select');
 
         /** @var Post $result */
         $result = Post::query()
-            ->addMetaToSelect('color')
+            ->addMetaToSelect('color', $alias)
             ->where(Post::POST_ID, $post->getId())
             ->first();
 
         $this->assertNotNull($result);
-        $this->assertEquals('blue', $result->getAttribute('color_value'));
+        $this->assertEquals('blue', $result->getAttribute($expectedAttribute));
     }
 
     /**
-     * @covers PostBuilder::addMetaToSelect
-     * @throws WpOrmException
-     * @return void
+     * @return \Generator<string, array{?string, string}>
      */
-    public function testAddMetaToSelectWithAlias(): void
+    public static function providerAddMetaToSelect(): \Generator
     {
-        $post = new Post();
-        $post->setPostTitle('Meta alias test');
-        $post->setPostName('meta-alias-test');
-        $post->setPostType('post');
-        $this->assertTrue($post->save());
-        $post->setMeta('color', 'red');
-
-        /** @var Post $result */
-        $result = Post::query()
-            ->addMetaToSelect('color', 'my_color')
-            ->where(Post::POST_ID, $post->getId())
-            ->first();
-
-        $this->assertNotNull($result);
-        $this->assertEquals('red', $result->getAttribute('my_color'));
+        yield 'default alias' => [null, 'color_value'];
+        yield 'custom alias'  => ['my_color', 'my_color'];
     }
 
     /**
+     * @param array<int|string, string> $argument
+     * @param array<string, string> $aliasFor
      * @covers PostBuilder::addMetasToSelect
+     * @dataProvider providerAddMetasToSelect
      * @throws WpOrmException
      * @return void
      */
-    public function testAddMetasToSelect(): void
+    public function testAddMetasToSelect(array $argument, array $aliasFor): void
     {
-        $post = new Post();
-        $post->setPostTitle('Multi meta test');
-        $post->setPostName('multi-meta-test');
-        $post->setPostType('post');
-        $this->assertTrue($post->save());
-        $post->setMeta('color', 'green');
-        $post->setMeta('size', 'large');
+        $post = $this->aPostWithMetas([
+            'color' => 'green',
+            'size' => 'large',
+        ], 'Add metas to select');
 
         /** @var Post $result */
         $result = Post::query()
-            ->addMetasToSelect(['color', 'size'])
+            ->addMetasToSelect($argument)
             ->where(Post::POST_ID, $post->getId())
             ->first();
 
         $this->assertNotNull($result);
-        $this->assertEquals('green', $result->getAttribute('color_value'));
-        $this->assertEquals('large', $result->getAttribute('size_value'));
+        $this->assertEquals('green', $result->getAttribute($aliasFor['color']));
+        $this->assertEquals('large', $result->getAttribute($aliasFor['size']));
     }
 
     /**
-     * @covers PostBuilder::addMetasToSelect
-     * @throws WpOrmException
-     * @return void
+     * @return \Generator<string, array{array<int|string, string>, array<string, string>}>
      */
-    public function testAddMetasToSelectWithAliases(): void
+    public static function providerAddMetasToSelect(): \Generator
     {
-        $post = new Post();
-        $post->setPostTitle('Multi meta alias test');
-        $post->setPostName('multi-meta-alias-test');
-        $post->setPostType('post');
-        $this->assertTrue($post->save());
-        $post->setMeta('color', 'yellow');
-        $post->setMeta('size', 'small');
-
-        /** @var Post $result */
-        $result = Post::query()
-            ->addMetasToSelect(['my_color' => 'color', 'my_size' => 'size'])
-            ->where(Post::POST_ID, $post->getId())
-            ->first();
-
-        $this->assertNotNull($result);
-        $this->assertEquals('yellow', $result->getAttribute('my_color'));
-        $this->assertEquals('small', $result->getAttribute('my_size'));
+        yield 'list (default aliases)' => [
+            ['color', 'size'],
+            ['color' => 'color_value', 'size' => 'size_value'],
+        ];
+        yield 'map (custom aliases)' => [
+            ['my_color' => 'color', 'my_size' => 'size'],
+            ['color' => 'my_color', 'size' => 'my_size'],
+        ];
     }
 
     /**
@@ -122,27 +97,16 @@ class PostBuilderTest extends TestCase
      */
     public function testAddMetaToFilter(): void
     {
-        $post1 = new Post();
-        $post1->setPostTitle('Filter test 1');
-        $post1->setPostName('filter-test-1');
-        $post1->setPostType('post');
-        $this->assertTrue($post1->save());
-        $post1->setMeta('priority', 'high');
-
-        $post2 = new Post();
-        $post2->setPostTitle('Filter test 2');
-        $post2->setPostName('filter-test-2');
-        $post2->setPostType('post');
-        $this->assertTrue($post2->save());
-        $post2->setMeta('priority', 'low');
+        $highPost = $this->aPostWithMetas(['priority' => 'high'], 'Filter test 1');
+        $lowPost = $this->aPostWithMetas(['priority' => 'low'], 'Filter test 2');
 
         $results = Post::query()
             ->addMetaToFilter('priority', 'high')
             ->get();
 
         $ids = $results->pluck(Post::POST_ID)->toArray();
-        $this->assertContains($post1->getId(), $ids);
-        $this->assertNotContains($post2->getId(), $ids);
+        $this->assertContains($highPost->getId(), $ids);
+        $this->assertNotContains($lowPost->getId(), $ids);
     }
 
     /**
@@ -152,27 +116,16 @@ class PostBuilderTest extends TestCase
      */
     public function testAddMetaToFilterWithOperator(): void
     {
-        $post1 = new Post();
-        $post1->setPostTitle('Operator test 1');
-        $post1->setPostName('operator-test-1');
-        $post1->setPostType('post');
-        $this->assertTrue($post1->save());
-        $post1->setMeta('level', 'B');
-
-        $post2 = new Post();
-        $post2->setPostTitle('Operator test 2');
-        $post2->setPostName('operator-test-2');
-        $post2->setPostType('post');
-        $this->assertTrue($post2->save());
-        $post2->setMeta('level', 'A');
+        $bPost = $this->aPostWithMetas(['level' => 'B'], 'Operator test 1');
+        $aPost = $this->aPostWithMetas(['level' => 'A'], 'Operator test 2');
 
         $results = Post::query()
             ->addMetaToFilter('level', 'A', '>')
             ->get();
 
         $ids = $results->pluck(Post::POST_ID)->toArray();
-        $this->assertContains($post1->getId(), $ids);
-        $this->assertNotContains($post2->getId(), $ids);
+        $this->assertContains($bPost->getId(), $ids);
+        $this->assertNotContains($aPost->getId(), $ids);
     }
 
     /**
@@ -182,12 +135,7 @@ class PostBuilderTest extends TestCase
      */
     public function testJoinToMetaDoesNotDuplicate(): void
     {
-        $post = new Post();
-        $post->setPostTitle('Duplicate join test');
-        $post->setPostName('duplicate-join-test');
-        $post->setPostType('post');
-        $this->assertTrue($post->save());
-        $post->setMeta('color', 'blue');
+        $post = $this->aPostWithMetas(['color' => 'blue'], 'Duplicate join test');
 
         $results = Post::query()
             ->addMetaToSelect('color')
@@ -206,13 +154,10 @@ class PostBuilderTest extends TestCase
      */
     public function testCombineMetaSelectAndFilter(): void
     {
-        $post = new Post();
-        $post->setPostTitle('Combine test');
-        $post->setPostName('combine-test');
-        $post->setPostType('post');
-        $this->assertTrue($post->save());
-        $post->setMeta('color', 'blue');
-        $post->setMeta('size', 'large');
+        $post = $this->aPostWithMetas([
+            'color' => 'blue',
+            'size' => 'large',
+        ], 'Combine test');
 
         $results = Post::query()
             ->addMetaToSelect('size')
@@ -232,18 +177,8 @@ class PostBuilderTest extends TestCase
      */
     public function testJoinToMetaWithLeftJoin(): void
     {
-        $postWith = new Post();
-        $postWith->setPostTitle('With meta');
-        $postWith->setPostName('with-meta');
-        $postWith->setPostType('post');
-        $this->assertTrue($postWith->save());
-        $postWith->setMeta('badge', 'gold');
-
-        $postWithout = new Post();
-        $postWithout->setPostTitle('Without meta');
-        $postWithout->setPostName('without-meta');
-        $postWithout->setPostType('post');
-        $this->assertTrue($postWithout->save());
+        $postWith = $this->aPostWithMetas(['badge' => 'gold'], 'With meta');
+        $postWithout = $this->aPost('Without meta');
 
         /** @var array $results */
         $results = Post::query()
@@ -255,8 +190,8 @@ class PostBuilderTest extends TestCase
     }
 
     /**
-     * @covers PostBuilder::joinToMeta
      * @return void
+     * @covers PostBuilder::joinToMeta
      */
     public function testJoinToMetaRejectsInvalidIdentifier(): void
     {
@@ -267,8 +202,8 @@ class PostBuilderTest extends TestCase
     }
 
     /**
-     * @covers PostBuilder::addMetaToSelect
      * @return void
+     * @covers PostBuilder::addMetaToSelect
      */
     public function testAddMetaToSelectRejectsInvalidAlias(): void
     {
@@ -279,8 +214,8 @@ class PostBuilderTest extends TestCase
     }
 
     /**
-     * @covers PostBuilder::addMetaToFilter
      * @return void
+     * @covers PostBuilder::addMetaToFilter
      */
     public function testAddMetaToFilterRejectsInvalidIdentifier(): void
     {
@@ -291,17 +226,14 @@ class PostBuilderTest extends TestCase
     }
 
     /**
-     * @covers PostBuilder::joinToMeta
      * @return void
+     * @covers PostBuilder::joinToMeta
      */
     public function testJoinToMetaUsesBoundMetaKeyValue(): void
     {
-        $post = new Post();
-        $post->setPostTitle('Bound binding test');
-        $post->setPostName('bound-binding-test');
-        $post->setPostType('post');
-        $this->assertTrue($post->save());
-        $post->setMeta('color', "red'; DROP TABLE wp_postmeta; --");
+        $post = $this->aPostWithMetas([
+            'color' => "red'; DROP TABLE wp_postmeta; --",
+        ], 'Bound binding test');
 
         $results = Post::query()
             ->addMetaToSelect('color')

--- a/tests/WordPress/Builders/UserBuilderTest.php
+++ b/tests/WordPress/Builders/UserBuilderTest.php
@@ -196,36 +196,6 @@ class UserBuilderTest extends TestCase
 
     /**
      * @return void
-     * @covers UserBuilder::whereEmail
-     */
-    public function testWhereEmailGeneratesCorrectSql(): void
-    {
-        User::query()
-            ->whereEmail('john@example.com')
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#users`.* from `#TABLE_PREFIX#users` where `user_email` = 'john@example.com'"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers UserBuilder::whereLogin
-     */
-    public function testWhereLoginGeneratesCorrectSql(): void
-    {
-        User::query()
-            ->whereLogin('john_doe')
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#users`.* from `#TABLE_PREFIX#users` where `user_login` = 'john_doe'"
-        );
-    }
-
-    /**
-     * @return void
      * @covers UserBuilder::whereEmails
      */
     public function testWhereEmailsWithSingleEmail(): void

--- a/tests/WordPress/Concerns/HasMetasTest.php
+++ b/tests/WordPress/Concerns/HasMetasTest.php
@@ -7,16 +7,20 @@
 namespace Dbout\WpOrm\Tests\WordPress\Concerns;
 
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Dbout\WpOrm\Concerns\HasMetas;
 use Dbout\WpOrm\Enums\YesNo;
 use Dbout\WpOrm\Models\Meta\AbstractMeta;
 use Dbout\WpOrm\Models\Meta\PostMeta;
 use Dbout\WpOrm\Models\Post;
+use Dbout\WpOrm\Tests\WordPress\Support\BuildsTestPost;
 use Dbout\WpOrm\Tests\WordPress\TestCase;
 use Illuminate\Events\Dispatcher;
 
 class HasMetasTest extends TestCase
 {
+    use BuildsTestPost;
+
     /**
      * @return void
      * @covers HasMetas::getMeta
@@ -24,9 +28,7 @@ class HasMetasTest extends TestCase
      */
     public function testGetMeta(): void
     {
-        $model = new Post();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
+        $model = $this->aPost(__FUNCTION__);
         $createMeta = $model->setMeta('author', 'Norman FOSTER');
 
         $meta = $model->getMeta('author');
@@ -45,10 +47,7 @@ class HasMetasTest extends TestCase
      */
     public function testGetAndSetMetaKey(): void
     {
-        $model = new Post();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-        $model->setMeta('author', 'Norman FOSTER');
+        $model = $this->aPostWithMetas(['author' => 'Norman FOSTER'], __FUNCTION__);
 
         $meta = $model->getMeta('author');
         $this->assertInstanceOf(AbstractMeta::class, $meta);
@@ -66,10 +65,7 @@ class HasMetasTest extends TestCase
      */
     public function testDeprecatedGetAndSetKeyStillWork(): void
     {
-        $model = new Post();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-        $model->setMeta('author', 'Norman FOSTER');
+        $model = $this->aPostWithMetas(['author' => 'Norman FOSTER'], __FUNCTION__);
 
         $meta = $model->getMeta('author');
         $this->assertInstanceOf(AbstractMeta::class, $meta);
@@ -89,9 +85,7 @@ class HasMetasTest extends TestCase
      */
     public function testSetMeta(): void
     {
-        $model = new Post();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
+        $model = $this->aPost(__FUNCTION__);
         $meta = $model->setMeta('build-by', 'John D.');
 
         $this->assertEquals('John D.', get_post_meta($model->getId(), 'build-by', true));
@@ -108,11 +102,7 @@ class HasMetasTest extends TestCase
      */
     public function testHasMeta(): void
     {
-        $model = new Post();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-
-        $model->setMeta('birthday-date', '17/09/1900');
+        $model = $this->aPostWithMetas(['birthday-date' => '17/09/1900'], __FUNCTION__);
         $this->assertTrue($model->hasMeta('birthday-date'));
 
         $wpMetaId = add_post_meta($model->getId(), 'birthday-place', 'France');
@@ -128,47 +118,41 @@ class HasMetasTest extends TestCase
      */
     public function testGetMetaValueWithoutCast(): void
     {
-        $model = new Post();
-        $model->setPostTitle(__FUNCTION__);
-
-        $model->save();
-        $model->setMeta('build-by', 'John D.');
+        $model = $this->aPostWithMetas(['build-by' => 'John D.'], __FUNCTION__);
 
         add_post_meta($model->getId(), 'place', 'Lyon, France');
         $this->assertEquals('Lyon, France', $model->getMetaValue('place'));
     }
 
     /**
+     * @param string $castType
+     * @param string $stored
+     * @param mixed $expected
      * @return void
      * @covers HasMetas::getMetaValue
+     * @dataProvider providerGenericCasts
      * @uses Post
      */
-    public function testGetMetaValueWithGenericCasts(): void
+    public function testGetMetaValueWithGenericCast(string $castType, string $stored, mixed $expected): void
     {
-        $object = new class () extends Post {
-            protected array $metaCasts = [
-                'age' => 'int',
-                'year' => 'integer',
-                'is_active' => 'bool',
-                'subscribed' => 'boolean',
-                'data'  => 'json',
-            ];
-        };
+        $model = $this->aPostWithMetaCasts(['value' => $castType], ['value' => $stored]);
+        $this->assertEquals($expected, $model->getMetaValue('value'));
+    }
 
-        $model = new $object();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-        $model->setMeta('age', '18');
-        $model->setMeta('year', '2024');
-        $model->setMeta('is_active', '1');
-        $model->setMeta('subscribed', '0');
-        $model->setMeta('data', '{"firstname":"John","lastname":"Doe"}');
-
-        $this->assertEquals(18, $model->getMetaValue('age'));
-        $this->assertEquals(2024, $model->getMetaValue('year'));
-        $this->assertTrue($model->getMetaValue('is_active'));
-        $this->assertFalse($model->getMetaValue('subscribed'));
-        $this->assertEquals(['firstname' => 'John', 'lastname' => 'Doe'], $model->getMetaValue('data'));
+    /**
+     * @return \Generator<string, array{string, string, mixed}>
+     */
+    public static function providerGenericCasts(): \Generator
+    {
+        yield 'int'        => ['int',     '18',   18];
+        yield 'integer'    => ['integer', '2024', 2024];
+        yield 'bool true'  => ['bool',    '1',    true];
+        yield 'bool false' => ['boolean', '0',    false];
+        yield 'json'       => [
+            'json',
+            '{"firstname":"John","lastname":"Doe"}',
+            ['firstname' => 'John', 'lastname' => 'Doe'],
+        ];
     }
 
     /**
@@ -178,16 +162,10 @@ class HasMetasTest extends TestCase
      */
     public function testGetMetaValueWithEnumCasts(): void
     {
-        $object = new class () extends Post {
-            protected array $metaCasts = [
-                'active' => YesNo::class,
-            ];
-        };
-
-        $model = new $object();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-        $model->setMeta('active', 'yes');
+        $model = $this->aPostWithMetaCasts(
+            ['active' => YesNo::class],
+            ['active' => 'yes'],
+        );
 
         /** @var YesNo $value */
         $value = $model->getMetaValue('active');
@@ -197,88 +175,81 @@ class HasMetasTest extends TestCase
     }
 
     /**
+     * @param string $castType
+     * @param string $stored
+     * @param string $expectedFormatted
+     * @param class-string $expectedClass
      * @return void
      * @covers HasMetas::getMetaValue
+     * @dataProvider providerDatetimeCasts
      * @uses Post
      */
-    public function testGetMetaValueWithDatetimeCasts(): void
-    {
-        $object = new class () extends Post {
-            protected array $metaCasts = [
-                'created_at' => 'datetime',
-                'uploaded_at' => 'date',
-            ];
-        };
+    public function testGetMetaValueWithDatetimeCast(
+        string $castType,
+        string $stored,
+        string $expectedFormatted,
+        string $expectedClass
+    ): void {
+        $model = $this->aPostWithMetaCasts(['value' => $castType], ['value' => $stored]);
 
-        $model = new $object();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-        $model->setMeta('created_at', '2022-09-08 07:30:05');
-        $model->setMeta('uploaded_at', '2024-10-08 10:25:35');
-
-        /** @var Carbon $date */
-        $date = $model->getMetaValue('created_at');
-        $this->assertInstanceOf(Carbon::class, $date);
-        $this->assertEquals('2022-09-08 07:30:05', $date->format('Y-m-d H:i:s'));
-
-        /** @var Carbon $date */
-        $date = $model->getMetaValue('uploaded_at');
-        $this->assertInstanceOf(Carbon::class, $date);
-        $this->assertEquals('2024-10-08 00:00:00', $date->format('Y-m-d H:i:s'), 'The time must be reset to 00:00:00.');
+        $value = $model->getMetaValue('value');
+        $this->assertInstanceOf($expectedClass, $value);
+        $this->assertEquals($expectedFormatted, $value->format('Y-m-d H:i:s'));
     }
 
     /**
-     * @return void
-     * @covers HasMetas::getMetaValue
-     * @uses Post
+     * @return \Generator<string, array{string, string, string, class-string}>
      */
-    public function testGetMetaValueWithDecimalCast(): void
+    public static function providerDatetimeCasts(): \Generator
     {
-        $object = new class () extends Post {
-            protected array $metaCasts = [
-                'price' => 'decimal:2',
-                'ratio' => 'decimal:4',
-            ];
-        };
-
-        $model = new $object();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-        $model->setMeta('price', '12.3456');
-        $model->setMeta('ratio', '0.5');
-
-        $this->assertSame('12.35', $model->getMetaValue('price'));
-        $this->assertSame('0.5000', $model->getMetaValue('ratio'));
+        yield 'datetime' => [
+            'datetime',
+            '2022-09-08 07:30:05',
+            '2022-09-08 07:30:05',
+            Carbon::class,
+        ];
+        yield 'date strips time' => [
+            'date',
+            '2024-10-08 10:25:35',
+            '2024-10-08 00:00:00',
+            Carbon::class,
+        ];
+        yield 'datetime with custom format' => [
+            'datetime:Y-m-d',
+            '2024-03-12 14:25:00',
+            '2024-03-12 14:25:00',
+            Carbon::class,
+        ];
+        yield 'immutable_datetime' => [
+            'immutable_datetime:Y-m-d H:i:s',
+            '2024-04-01 09:00:00',
+            '2024-04-01 09:00:00',
+            CarbonImmutable::class,
+        ];
     }
 
     /**
+     * @param string $castType
+     * @param string $stored
+     * @param string $expected
      * @return void
      * @covers HasMetas::getMetaValue
+     * @dataProvider providerDecimalCasts
      * @uses Post
      */
-    public function testGetMetaValueWithCustomDatetimeCasts(): void
+    public function testGetMetaValueWithDecimalCast(string $castType, string $stored, string $expected): void
     {
-        $object = new class () extends Post {
-            protected array $metaCasts = [
-                'published_at' => 'datetime:Y-m-d',
-                'archived_at' => 'immutable_datetime:Y-m-d H:i:s',
-            ];
-        };
+        $model = $this->aPostWithMetaCasts(['value' => $castType], ['value' => $stored]);
+        $this->assertSame($expected, $model->getMetaValue('value'));
+    }
 
-        $model = new $object();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-        $model->setMeta('published_at', '2024-03-12 14:25:00');
-        $model->setMeta('archived_at', '2024-04-01 09:00:00');
-
-        /** @var Carbon $published */
-        $published = $model->getMetaValue('published_at');
-        $this->assertInstanceOf(Carbon::class, $published);
-        $this->assertEquals('2024-03-12 14:25:00', $published->format('Y-m-d H:i:s'));
-
-        $archived = $model->getMetaValue('archived_at');
-        $this->assertInstanceOf(\Carbon\CarbonImmutable::class, $archived);
-        $this->assertEquals('2024-04-01 09:00:00', $archived->format('Y-m-d H:i:s'));
+    /**
+     * @return \Generator<string, array{string, string, string}>
+     */
+    public static function providerDecimalCasts(): \Generator
+    {
+        yield 'decimal:2 rounds' => ['decimal:2', '12.3456', '12.35'];
+        yield 'decimal:4 pads'   => ['decimal:4', '0.5',     '0.5000'];
     }
 
     /**
@@ -288,17 +259,7 @@ class HasMetasTest extends TestCase
      */
     public function testGetMetaValueWithInvalidCasts(): void
     {
-        $object = new class () extends Post {
-            protected array $metaCasts = [
-                'my_meta' => 'boolean_',
-            ];
-        };
-
-        $model = new $object();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-        $model->setMeta('my_meta', 'yes');
-
+        $model = $this->aPostWithMetaCasts(['my_meta' => 'boolean_'], ['my_meta' => 'yes']);
         $this->assertEquals('yes', $model->getMetaValue('my_meta'));
     }
 
@@ -309,11 +270,7 @@ class HasMetasTest extends TestCase
      */
     public function testDeleteMeta(): void
     {
-        $model = new Post();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-
-        $model->setMeta('architect-name', 'Norman F.');
+        $model = $this->aPostWithMetas(['architect-name' => 'Norman F.'], __FUNCTION__);
 
         $this->assertEquals(1, $model->deleteMeta('architect-name'), 'The function must delete only one line.');
         $this->assertFalse($model->hasMeta('architect-name'), 'The meta must no longer exist.');
@@ -326,11 +283,7 @@ class HasMetasTest extends TestCase
      */
     public function testDeleteUndefinedMeta(): void
     {
-        $model = new Post();
-        $model->setPostTitle(__FUNCTION__);
-        $model->save();
-
-        $model->setMeta('architect-name', 'Norman F.');
+        $model = $this->aPostWithMetas(['architect-name' => 'Norman F.'], __FUNCTION__);
 
         $this->assertEquals(0, $model->deleteMeta('fake-meta'));
         $this->assertTrue($model->hasMeta('architect-name'), 'The unrelated meta must still exist.');

--- a/tests/WordPress/Concerns/HasMetasTest.php
+++ b/tests/WordPress/Concerns/HasMetasTest.php
@@ -30,7 +30,6 @@ class HasMetasTest extends TestCase
         $createMeta = $model->setMeta('author', 'Norman FOSTER');
 
         $meta = $model->getMeta('author');
-        $this->assertLastQueryEquals($this->getQueryGetMeta($model->getId(), 'author'));
         $this->assertInstanceOf(AbstractMeta::class, $meta);
         $this->assertEquals($createMeta->getId(), $meta->getId());
         $this->assertEquals($createMeta->getValue(), $meta->getValue());
@@ -137,7 +136,6 @@ class HasMetasTest extends TestCase
 
         add_post_meta($model->getId(), 'place', 'Lyon, France');
         $this->assertEquals('Lyon, France', $model->getMetaValue('place'));
-        $this->assertLastQueryEquals($this->getQueryGetMeta($model->getId(), 'place'));
     }
 
     /**
@@ -318,12 +316,6 @@ class HasMetasTest extends TestCase
         $model->setMeta('architect-name', 'Norman F.');
 
         $this->assertEquals(1, $model->deleteMeta('architect-name'), 'The function must delete only one line.');
-        $this->assertLastQueryEquals(sprintf(
-            "delete from `%1\$s` where `%1\$s`.`post_id` = %2\$d and `%1\$s`.`post_id` is not null and `meta_key` = 'architect-name'",
-            '#TABLE_PREFIX#postmeta',
-            $model->getId()
-        ));
-
         $this->assertFalse($model->hasMeta('architect-name'), 'The meta must no longer exist.');
     }
 
@@ -341,12 +333,7 @@ class HasMetasTest extends TestCase
         $model->setMeta('architect-name', 'Norman F.');
 
         $this->assertEquals(0, $model->deleteMeta('fake-meta'));
-
-        $this->assertLastQueryEquals(sprintf(
-            "delete from `%1\$s` where `%1\$s`.`post_id` = %2\$d and `%1\$s`.`post_id` is not null and `meta_key` = 'fake-meta'",
-            '#TABLE_PREFIX#postmeta',
-            $model->getId()
-        ));
+        $this->assertTrue($model->hasMeta('architect-name'), 'The unrelated meta must still exist.');
     }
 
     /**
@@ -377,20 +364,5 @@ class HasMetasTest extends TestCase
         $this->assertEquals($metaValue, get_post_meta($model->getId(), $metaKey, true));
         $this->assertInstanceOf(PostMeta::class, $model->getMeta($metaKey));
         $this->assertTrue($model->hasMeta($metaKey));
-    }
-
-    /**
-     * @param int $postId
-     * @param string $metaKey
-     * @return string
-     */
-    private function getQueryGetMeta(int $postId, string $metaKey): string
-    {
-        return sprintf(
-            "select * from `%1\$s` where `%1\$s`.`post_id` = %2\$d and `%1\$s`.`post_id` is not null and `meta_key` = '%3\$s' limit 1",
-            '#TABLE_PREFIX#postmeta',
-            $postId,
-            $metaKey
-        );
     }
 }

--- a/tests/WordPress/Concerns/PrunableTest.php
+++ b/tests/WordPress/Concerns/PrunableTest.php
@@ -8,19 +8,23 @@ namespace Dbout\WpOrm\Tests\WordPress\Concerns;
 
 use Carbon\Carbon;
 use Dbout\WpOrm\Orm\AbstractModel;
-use Dbout\WpOrm\Orm\Database;
+use Dbout\WpOrm\Tests\WordPress\Support\CreatesCustomTable;
 use Dbout\WpOrm\Tests\WordPress\TestCase;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Schema\Blueprint;
 
 class PrunableTest extends TestCase
 {
+    use CreatesCustomTable;
+
     /**
      * @inheritDoc
      */
     public static function setUpBeforeClass(): void
     {
-        Database::getInstance()->getSchemaBuilder()->create('sales_payment', function (Blueprint $table) {
+        parent::setUpBeforeClass();
+
+        self::createCustomTable('sales_payment', function (Blueprint $table) {
             $table->id();
             $table->date('created_at');
             $table->string('method');

--- a/tests/WordPress/Models/CommentTest.php
+++ b/tests/WordPress/Models/CommentTest.php
@@ -34,7 +34,6 @@ class CommentTest extends TestCase
 
         $reloadComment = Comment::find($comment->getId());
         $user = $reloadComment->user;
-        $this->assertLastQueryBelongsToRelation('users', 'ID', $userId);
 
         $this->assertInstanceOf(User::class, $user);
         $this->assertEquals($userId, $user->getId());
@@ -62,7 +61,6 @@ class CommentTest extends TestCase
 
         $reloadComment = Comment::find($comment->getId());
         $post = $reloadComment->post;
-        $this->assertLastQueryBelongsToRelation('posts', 'ID', $postId);
 
         $this->assertInstanceOf(Post::class, $post);
         $this->assertEquals($postId, $post->getId());
@@ -89,7 +87,6 @@ class CommentTest extends TestCase
 
         $reloadComment = Comment::find($comment->getId());
         $parent = $reloadComment->parent;
-        $this->assertLastQueryBelongsToRelation('comments', 'comment_ID', $objectId);
 
         $this->assertInstanceOf(Comment::class, $parent);
         $this->assertEquals($objectId, $parent->getId());

--- a/tests/WordPress/Models/CustomCommentTest.php
+++ b/tests/WordPress/Models/CustomCommentTest.php
@@ -29,10 +29,6 @@ class CustomCommentTest extends TestCase
         $this->assertInstanceOf($model::class, $object);
         $this->assertEquals('woocommerce', $object->getCommentType());
         $this->assertEquals($objectId, $object->getId());
-        $this->assertLastQueryEquals(sprintf(
-            "select `#TABLE_PREFIX#comments`.* from `#TABLE_PREFIX#comments` where `#TABLE_PREFIX#comments`.`comment_ID` = %s and `comment_type` = 'woocommerce' limit 1",
-            $objectId
-        ));
     }
 
     /**
@@ -51,11 +47,6 @@ class CustomCommentTest extends TestCase
 
         $object = $model::find($objectId);
         $this->assertNull($object);
-
-        $this->assertLastQueryEquals(sprintf(
-            "select `#TABLE_PREFIX#comments`.* from `#TABLE_PREFIX#comments` where `#TABLE_PREFIX#comments`.`comment_ID` = %s and `comment_type` = 'author' limit 1",
-            $objectId
-        ));
     }
 
     /**
@@ -105,10 +96,6 @@ class CustomCommentTest extends TestCase
         };
 
         $comments = $model::all();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#comments`.* from `#TABLE_PREFIX#comments` where `comment_type` = 'application'"
-        );
 
         $applicationComments = array_merge($applicationCommentsV1, $applicationCommentsV2);
         $this->assertEquals(12, $comments->count());
@@ -163,10 +150,6 @@ class CustomCommentTest extends TestCase
         $comment->save();
         $commentId = $comment->getId();
         $this->assertTrue($comment->delete());
-        $this->assertLastQueryEquals(sprintf(
-            "delete from `#TABLE_PREFIX#comments` where `comment_ID` = %s",
-            $commentId
-        ));
 
         $wpComment = get_comment($commentId);
         $this->assertNull($wpComment);

--- a/tests/WordPress/Models/CustomPostTest.php
+++ b/tests/WordPress/Models/CustomPostTest.php
@@ -29,11 +29,6 @@ class CustomPostTest extends TestCase
         $this->assertInstanceOf($model::class, $object);
         $this->assertEquals('architect', $object->getPostType());
         $this->assertEquals($objectId, $object->getId());
-
-        $this->assertLastQueryEquals(sprintf(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `#TABLE_PREFIX#posts`.`ID` = %s and `post_type` = 'architect' limit 1",
-            $objectId
-        ));
     }
 
     /**
@@ -52,10 +47,6 @@ class CustomPostTest extends TestCase
 
         $object = $model::find($objectId);
         $this->assertNull($object, 'Value must be null because cannot load another post_type object.');
-        $this->assertLastQueryEquals(sprintf(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `#TABLE_PREFIX#posts`.`ID` = %s and `post_type` = 'architect' limit 1",
-            $objectId
-        ));
     }
 
     /**
@@ -110,10 +101,6 @@ class CustomPostTest extends TestCase
 
         $projects = $model::all();
 
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `post_type` = 'project'"
-        );
-
         $objectIds = array_merge($objectsV1, $objectsV2);
         $this->assertEquals(12, $projects->count());
         $this->assertEquals($objectIds, $projects->pluck('ID')->toArray());
@@ -136,10 +123,6 @@ class CustomPostTest extends TestCase
 
         $objectId = $order->getId();
         $this->assertTrue($order->delete());
-        $this->assertLastQueryEquals(sprintf(
-            "delete from `#TABLE_PREFIX#posts` where `ID` = %s",
-            $objectId
-        ));
 
         $wpObject = get_post($objectId);
         $this->assertNull($wpObject);

--- a/tests/WordPress/Models/OptionTest.php
+++ b/tests/WordPress/Models/OptionTest.php
@@ -23,7 +23,6 @@ class OptionTest extends TestCase
         $option = Option::findOneByName('my_custom_option');
 
         $this->assertInstanceOf(Option::class, $option);
-        $this->assertFindLastQuery('options', 'option_name', 'my_custom_option');
         $this->assertEquals('option_value', $option->getOptionValue());
         $this->assertEquals('my_custom_option', $option->getOptionName());
     }

--- a/tests/WordPress/Models/PostTest.php
+++ b/tests/WordPress/Models/PostTest.php
@@ -105,7 +105,6 @@ class PostTest extends TestCase
 
         $newObject = Post::find($object->getId());
         $parent = $newObject->parent;
-        $this->assertLastQueryBelongsToRelation('posts', 'ID', $objectId);
 
         $this->assertInstanceOf(Post::class, $parent);
         $this->assertEquals($objectId, $parent->getId());
@@ -134,7 +133,6 @@ class PostTest extends TestCase
 
         $newObject = Post::find($object->getId());
         $author = $newObject->author;
-        $this->assertLastQueryBelongsToRelation('users', 'ID', $userId);
         $this->assertInstanceOf(User::class, $author);
         $this->assertEquals($userId, $author->getId());
     }

--- a/tests/WordPress/Models/UserTest.php
+++ b/tests/WordPress/Models/UserTest.php
@@ -42,11 +42,7 @@ class UserTest extends TestCase
      */
     public function testFindOneByEmail(): void
     {
-        $this->checkFindOneResult(
-            User::findOneByEmail(self::USER_EMAIL),
-            'user_email',
-            self::USER_EMAIL
-        );
+        $this->checkFindOneResult(User::findOneByEmail(self::USER_EMAIL));
     }
 
     /**
@@ -55,11 +51,7 @@ class UserTest extends TestCase
      */
     public function testFindOneByLogin(): void
     {
-        $this->checkFindOneResult(
-            User::findOneByLogin(self::USER_LOGIN),
-            'user_login',
-            self::USER_LOGIN
-        );
+        $this->checkFindOneResult(User::findOneByLogin(self::USER_LOGIN));
     }
 
     /**
@@ -112,15 +104,11 @@ class UserTest extends TestCase
 
     /**
      * @param User|null $user
-     * @param string $whereColumn
-     * @param string $whereValue
      * @return void
      */
-    private function checkFindOneResult(?User $user, string $whereColumn, string $whereValue): void
+    private function checkFindOneResult(?User $user): void
     {
         $this->assertInstanceOf(User::class, $user);
-        $this->assertFindLastQuery('users', $whereColumn, $whereValue);
-
         $this->assertEquals(self::$testingUserId, $user->getId());
         $this->assertEquals(self::USER_LOGIN, $user->getUserLogin());
         $this->assertEquals(self::USER_EMAIL, $user->getUserEmail());

--- a/tests/WordPress/Multisite/MultisiteBootTest.php
+++ b/tests/WordPress/Multisite/MultisiteBootTest.php
@@ -20,6 +20,7 @@ class MultisiteBootTest extends TestCase
 
     /**
      * @return void
+     * @coversNothing
      */
     public function testSuiteBootsInMultisite(): void
     {
@@ -30,6 +31,7 @@ class MultisiteBootTest extends TestCase
 
     /**
      * @return void
+     * @coversNothing
      */
     public function testInBlogRestoresCurrentBlogIdEvenOnException(): void
     {

--- a/tests/WordPress/Multisite/MultisiteBootTest.php
+++ b/tests/WordPress/Multisite/MultisiteBootTest.php
@@ -13,6 +13,8 @@ use Dbout\WpOrm\Tests\WordPress\TestCase;
  * Smoke test that proves the suite is running in multisite mode when the
  * dedicated CI job kicks in. Real ORM-level multisite coverage will land
  * with the v6 multisite implementation.
+ *
+ * @group multisite
  */
 class MultisiteBootTest extends TestCase
 {

--- a/tests/WordPress/Multisite/MultisiteBootTest.php
+++ b/tests/WordPress/Multisite/MultisiteBootTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Multisite;
+
+use Dbout\WpOrm\Tests\WordPress\Support\RunsInMultisite;
+use Dbout\WpOrm\Tests\WordPress\TestCase;
+
+/**
+ * Smoke test that proves the suite is running in multisite mode when the
+ * dedicated CI job kicks in. Real ORM-level multisite coverage will land
+ * with the v6 multisite implementation.
+ */
+class MultisiteBootTest extends TestCase
+{
+    use RunsInMultisite;
+
+    /**
+     * @return void
+     */
+    public function testSuiteBootsInMultisite(): void
+    {
+        $this->assertTrue(is_multisite());
+        $this->assertTrue(function_exists('switch_to_blog'));
+        $this->assertTrue(function_exists('restore_current_blog'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testInBlogRestoresCurrentBlogIdEvenOnException(): void
+    {
+        $initialBlogId = get_current_blog_id();
+        $caught = null;
+
+        try {
+            $this->inBlog($initialBlogId, function (): void {
+                throw new \RuntimeException('test boundary');
+            });
+        } catch (\RuntimeException $e) {
+            $caught = $e;
+        }
+
+        $this->assertNotNull($caught, 'Expected exception to propagate.');
+        $this->assertSame($initialBlogId, get_current_blog_id());
+    }
+}

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -142,7 +142,8 @@ class AbstractModelWithCustomTableTest extends TestCase
         }
 
         $selectedIds = self::$model::query()->where('metadata->address.country', 'SE')->get()->pluck('id')->toArray();
-        $this->assertLastQueryEquals("select * from `#TABLE_PREFIX#custom_table` where json_unquote(json_extract(`metadata`, '$.address.country')) = 'SE'");
+        // Pin the WordPressGrammar JSON idiom; full SQL shape is implementation detail.
+        $this->assertLastQueryContains("json_unquote(json_extract(`metadata`, '$.address.country'))");
         $this->assertEquals($seIds, $selectedIds);
     }
 
@@ -191,7 +192,7 @@ class AbstractModelWithCustomTableTest extends TestCase
         }
 
         $selectedIds = self::$model::query()->where('metadata->type', 'edm')->get()->pluck('id')->toArray();
-        $this->assertLastQueryEquals("select * from `#TABLE_PREFIX#custom_table` where json_unquote(json_extract(`metadata`, '$.type')) = 'edm'");
+        $this->assertLastQueryContains("json_unquote(json_extract(`metadata`, '$.type'))");
         $this->assertEquals($edmIds, $selectedIds);
     }
 

--- a/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
+++ b/tests/WordPress/Orm/AbstractModelWithCustomTableTest.php
@@ -7,10 +7,14 @@
 namespace Dbout\WpOrm\Tests\WordPress\Orm;
 
 use Dbout\WpOrm\Orm\AbstractModel;
+use Dbout\WpOrm\Tests\WordPress\Support\CreatesCustomTable;
 use Dbout\WpOrm\Tests\WordPress\TestCase;
+use Illuminate\Database\Schema\Blueprint;
 
 class AbstractModelWithCustomTableTest extends TestCase
 {
+    use CreatesCustomTable;
+
     private const TABLE_NAME = 'custom_table';
     private static AbstractModel $model;
 
@@ -19,19 +23,14 @@ class AbstractModelWithCustomTableTest extends TestCase
      */
     public static function setUpBeforeClass(): void
     {
-        global $wpdb;
+        parent::setUpBeforeClass();
 
-        $tableName = $wpdb->prefix . self::TABLE_NAME;
-        $sql = "CREATE TABLE $tableName (
-            id INT NOT NULL AUTO_INCREMENT,
-            name varchar(100) NOT NULL,
-            url varchar(55) DEFAULT '' NOT NULL,
-            metadata JSON,
-            PRIMARY KEY  (id)
-        );";
-
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta($sql);
+        self::createCustomTable(self::TABLE_NAME, function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->string('url', 55)->default('');
+            $table->json('metadata')->nullable();
+        });
 
         self::$model = new class () extends AbstractModel {
             protected $primaryKey = 'id';

--- a/tests/WordPress/Orm/DatabaseTransactionTest.php
+++ b/tests/WordPress/Orm/DatabaseTransactionTest.php
@@ -34,7 +34,6 @@ class DatabaseTransactionTest extends TestCase
 
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta($sql);
-        define('SAVEQUERIES', true);
     }
 
     /**

--- a/tests/WordPress/Orm/DatabaseTransactionTest.php
+++ b/tests/WordPress/Orm/DatabaseTransactionTest.php
@@ -8,11 +8,15 @@ namespace Dbout\WpOrm\Tests\WordPress\Orm;
 
 use Dbout\WpOrm\Orm\AbstractModel;
 use Dbout\WpOrm\Orm\Database;
+use Dbout\WpOrm\Tests\WordPress\Support\CreatesCustomTable;
 use Dbout\WpOrm\Tests\WordPress\TestCase;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
 
 class DatabaseTransactionTest extends TestCase
 {
+    use CreatesCustomTable;
+
     private string $tableName = '';
     private AbstractModel $model;
     private Database $db;
@@ -22,18 +26,13 @@ class DatabaseTransactionTest extends TestCase
      */
     public static function setUpBeforeClass(): void
     {
-        global $wpdb;
+        parent::setUpBeforeClass();
 
-        $tableName = $wpdb->prefix . 'document';
-        $sql = "CREATE TABLE $tableName (
-            id INT NOT NULL AUTO_INCREMENT,
-            name varchar(100) NOT NULL,
-            url varchar(55) DEFAULT '' NOT NULL,
-            PRIMARY KEY  (id)
-        );";
-
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta($sql);
+        self::createCustomTable('document', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->string('url', 55)->default('');
+        });
     }
 
     /**

--- a/tests/WordPress/Orm/DatabaseTransactionTest.php
+++ b/tests/WordPress/Orm/DatabaseTransactionTest.php
@@ -132,8 +132,12 @@ class DatabaseTransactionTest extends TestCase
      */
     public function testBeginTransaction(): void
     {
+        $startLevel = $this->db->transactionLevel();
         $this->db->beginTransaction();
-        $this->assertLastQueryEquals('START TRANSACTION;');
+        $this->assertSame($startLevel + 1, $this->db->transactionLevel());
+
+        // Clean up so the next test does not inherit an open transaction.
+        $this->db->rollBack();
     }
 
     /**
@@ -143,9 +147,10 @@ class DatabaseTransactionTest extends TestCase
      */
     public function testRollback(): void
     {
+        $startLevel = $this->db->transactionLevel();
         $this->db->beginTransaction();
         $this->db->rollBack();
-        $this->assertLastQueryEquals('ROLLBACK;');
+        $this->assertSame($startLevel, $this->db->transactionLevel());
     }
 
     /**
@@ -155,9 +160,10 @@ class DatabaseTransactionTest extends TestCase
      */
     public function testCommit(): void
     {
+        $startLevel = $this->db->transactionLevel();
         $this->db->beginTransaction();
         $this->db->commit();
-        $this->assertLastQueryEquals('COMMIT;');
+        $this->assertSame($startLevel, $this->db->transactionLevel());
     }
 
     /**

--- a/tests/WordPress/Support/BuildsTestPost.php
+++ b/tests/WordPress/Support/BuildsTestPost.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Support;
+
+use Dbout\WpOrm\Models\Post;
+
+/**
+ * Test fixture helpers to reduce the new-Post-set-title-set-name-set-type-save
+ * boilerplate that recurs across builder, meta and concern tests.
+ *
+ * @see TESTS_AUDIT.md point #5 (data providers + BuildsTestPost trait)
+ */
+trait BuildsTestPost
+{
+    /**
+     * Create and save a Post with sensible defaults.
+     *
+     * @param string $title
+     * @param string $type
+     * @return Post
+     */
+    protected function aPost(string $title = 'Test post', string $type = 'post'): Post
+    {
+        $post = new Post();
+        $post->setPostTitle($title);
+        $post->setPostName(sanitize_title($title));
+        $post->setPostType($type);
+        $post->save();
+
+        return $post;
+    }
+
+    /**
+     * Create and save a Post, then attach the given metas one by one (after
+     * save, so no event dispatcher is required).
+     *
+     * @param array<string, mixed> $metas
+     * @param string $title
+     * @param string $type
+     * @return Post
+     */
+    protected function aPostWithMetas(
+        array $metas,
+        string $title = 'Test post with metas',
+        string $type = 'post'
+    ): Post {
+        $post = $this->aPost($title, $type);
+        foreach ($metas as $key => $value) {
+            $post->setMeta($key, $value);
+        }
+
+        return $post;
+    }
+
+    /**
+     * Create and save a Post-derived anonymous class with custom $metaCasts,
+     * then attach the given metas. Used by HasMetas cast tests where the
+     * cast configuration must be set at class level.
+     *
+     * @param array<string, string> $casts Map of meta key → cast type.
+     * @param array<string, mixed>  $metas Optional metas to set after save.
+     * @param string                $title
+     * @return Post
+     */
+    protected function aPostWithMetaCasts(
+        array $casts,
+        array $metas = [],
+        string $title = 'Test cast post'
+    ): Post {
+        $post = new class () extends Post {
+            /**
+             * @var array<string, string>
+             */
+            protected array $metaCasts = [];
+
+            /**
+             * @param array<string, string> $casts
+             * @return self
+             */
+            public function withMetaCasts(array $casts): self
+            {
+                $this->metaCasts = $casts;
+                return $this;
+            }
+        };
+
+        $post->withMetaCasts($casts);
+        $post->setPostTitle($title);
+        $post->setPostName(sanitize_title($title));
+        $post->setPostType('post');
+        $post->save();
+
+        foreach ($metas as $key => $value) {
+            $post->setMeta($key, $value);
+        }
+
+        return $post;
+    }
+}

--- a/tests/WordPress/Support/CreatesCustomTable.php
+++ b/tests/WordPress/Support/CreatesCustomTable.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Support;
+
+use Dbout\WpOrm\Orm\Database;
+use Illuminate\Database\Schema\Blueprint;
+
+/**
+ * Helper for tests that need a custom database table for the lifetime of the test class.
+ *
+ * Tables registered via createCustomTable() are dropped automatically in
+ * tearDownAfterClass(). This avoids the leak that occurs when tests call
+ * dbDelta() or Schema::create() without ever cleaning up afterwards
+ * (cf. TESTS_AUDIT.md point #3).
+ *
+ * Usage:
+ *
+ *     class FooTest extends TestCase
+ *     {
+ *         use CreatesCustomTable;
+ *
+ *         public static function setUpBeforeClass(): void
+ *         {
+ *             parent::setUpBeforeClass();
+ *             self::createCustomTable('document', function (Blueprint $table) {
+ *                 $table->id();
+ *                 $table->string('name', 100);
+ *             });
+ *         }
+ *     }
+ */
+trait CreatesCustomTable
+{
+    /**
+     * Tables created by createCustomTable() during setUpBeforeClass.
+     *
+     * @var array<string>
+     */
+    private static array $customTables = [];
+
+    /**
+     * Create a custom table that is dropped automatically in tearDownAfterClass().
+     *
+     * The connection prefix is applied automatically — pass the table name without it.
+     *
+     * @param string $name
+     * @param \Closure(Blueprint): void $blueprint
+     * @return void
+     */
+    protected static function createCustomTable(string $name, \Closure $blueprint): void
+    {
+        $schema = Database::getInstance()->getSchemaBuilder();
+
+        // Drop a leftover table from a previously interrupted run before recreating.
+        $schema->dropIfExists($name);
+        $schema->create($name, $blueprint);
+
+        self::$customTables[] = $name;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function tearDownAfterClass(): void
+    {
+        $schema = Database::getInstance()->getSchemaBuilder();
+        foreach (self::$customTables as $name) {
+            $schema->dropIfExists($name);
+        }
+
+        self::$customTables = [];
+
+        parent::tearDownAfterClass();
+    }
+}

--- a/tests/WordPress/Support/RunsInMultisite.php
+++ b/tests/WordPress/Support/RunsInMultisite.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Support;
+
+/**
+ * Test case helpers for running against a WordPress multisite install.
+ *
+ * The package itself does not currently support multisite (cf. README and
+ * the v6 milestone). This trait is the test-side scaffolding so that v6
+ * work can focus on the ORM layer and not on test plumbing.
+ *
+ * Usage:
+ *
+ *     class FooMultisiteTest extends TestCase
+ *     {
+ *         use RunsInMultisite;
+ *
+ *         public function testSomething(): void
+ *         {
+ *             // Auto-skipped when the suite is run without WP_MULTISITE=1.
+ *             $value = $this->inBlog($this->createSubsiteId(), function () {
+ *                 return get_option('blogname');
+ *             });
+ *             $this->assertSame('subsite', $value);
+ *         }
+ *     }
+ */
+trait RunsInMultisite
+{
+    /**
+     * Skip the test when the WordPress test suite is not booted in
+     * multisite mode (set WP_MULTISITE=1 or define WP_TESTS_MULTISITE).
+     *
+     * @before
+     * @return void
+     */
+    protected function skipIfNotMultisite(): void
+    {
+        if (!is_multisite()) {
+            $this->markTestSkipped('Multisite-only test — run with WP_MULTISITE=1.');
+        }
+    }
+
+    /**
+     * @param int $blogId
+     * @return void
+     */
+    protected function switchToBlog(int $blogId): void
+    {
+        switch_to_blog($blogId);
+    }
+
+    /**
+     * @return void
+     */
+    protected function restoreBlog(): void
+    {
+        restore_current_blog();
+    }
+
+    /**
+     * Run the callback inside a switched-blog context, restoring the
+     * previous blog regardless of whether the callback throws. Prefer
+     * this form over manual switch / restore — it can't leak state.
+     *
+     * @template T
+     * @param int $blogId
+     * @param \Closure(): T $callback
+     * @return T
+     */
+    protected function inBlog(int $blogId, \Closure $callback): mixed
+    {
+        $this->switchToBlog($blogId);
+        try {
+            return $callback();
+        } finally {
+            $this->restoreBlog();
+        }
+    }
+}

--- a/tests/WordPress/Taps/Attachment/IsMimeTypeTapTest.php
+++ b/tests/WordPress/Taps/Attachment/IsMimeTypeTapTest.php
@@ -135,18 +135,4 @@ class IsMimeTypeTapTest extends TestCase
         $this->assertEquals($attachmentId, $first->getId());
     }
 
-    /**
-     * @return void
-     * @covers IsMimeTypeTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQuery(): void
-    {
-        Attachment::query()
-            ->tap(new IsMimeTypeTap(self::MIME_JPEG))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `post_mime_type` = 'image/jpeg' and `post_type` = 'attachment'"
-        );
-    }
 }

--- a/tests/WordPress/Taps/Comment/IsApprovedTapTest.php
+++ b/tests/WordPress/Taps/Comment/IsApprovedTapTest.php
@@ -273,33 +273,4 @@ class IsApprovedTapTest extends TestCase
         $this->assertEquals($postId, $first->getCommentPostID());
     }
 
-    /**
-     * @return void
-     * @covers IsApprovedTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQueryForApproved(): void
-    {
-        Comment::query()
-            ->tap(new IsApprovedTap(true))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#comments`.* from `#TABLE_PREFIX#comments` where `comment_approved` = 1"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsApprovedTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQueryForUnapproved(): void
-    {
-        Comment::query()
-            ->tap(new IsApprovedTap(false))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#comments`.* from `#TABLE_PREFIX#comments` where `comment_approved` = 0"
-        );
-    }
 }

--- a/tests/WordPress/Taps/Comment/IsCommentTypeTapTest.php
+++ b/tests/WordPress/Taps/Comment/IsCommentTypeTapTest.php
@@ -217,36 +217,6 @@ class IsCommentTypeTapTest extends TestCase
      * @return void
      * @covers IsCommentTypeTap::__invoke
      */
-    public function testGeneratesCorrectSqlQuery(): void
-    {
-        Comment::query()
-            ->tap(new IsCommentTypeTap('review'))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#comments`.* from `#TABLE_PREFIX#comments` where `comment_type` = 'review'"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsCommentTypeTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQueryForEmptyType(): void
-    {
-        Comment::query()
-            ->tap(new IsCommentTypeTap(''))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#comments`.* from `#TABLE_PREFIX#comments` where `comment_type` = ''"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsCommentTypeTap::__invoke
-     */
     public function testDistinguishesBetweenDifferentCustomTypes(): void
     {
         self::factory()->comment->create([

--- a/tests/WordPress/Taps/Comment/IsUserTapTest.php
+++ b/tests/WordPress/Taps/Comment/IsUserTapTest.php
@@ -288,45 +288,6 @@ class IsUserTapTest extends TestCase
      * @return void
      * @covers IsUserTap::__invoke
      */
-    public function testGeneratesCorrectSqlQueryWithInteger(): void
-    {
-        $userId = 42;
-
-        Comment::query()
-            ->tap(new IsUserTap($userId))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#comments`.* from `#TABLE_PREFIX#comments` where `user_id` = 42"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsUserTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQueryWithUserModel(): void
-    {
-        $userId = self::factory()->user->create([
-            'user_login' => 'john_doe',
-            'user_email' => 'john@example.com',
-        ]);
-
-        $user = User::find($userId);
-
-        Comment::query()
-            ->tap(new IsUserTap($user))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            sprintf("select `#TABLE_PREFIX#comments`.* from `#TABLE_PREFIX#comments` where `user_id` = %d", $userId)
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsUserTap::__invoke
-     */
     public function testDistinguishesBetweenDifferentUsers(): void
     {
         $user1Id = self::factory()->user->create([

--- a/tests/WordPress/Taps/Post/IsAuthorTapTest.php
+++ b/tests/WordPress/Taps/Post/IsAuthorTapTest.php
@@ -221,45 +221,6 @@ class IsAuthorTapTest extends TestCase
      * @return void
      * @covers IsAuthorTap::__invoke
      */
-    public function testGeneratesCorrectSqlQueryWithInteger(): void
-    {
-        $authorId = 42;
-
-        Post::query()
-            ->tap(new IsAuthorTap($authorId))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `post_author` = 42"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsAuthorTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQueryWithUserModel(): void
-    {
-        $authorId = self::factory()->user->create([
-            'user_login' => 'john_doe',
-            'user_email' => self::EMAIL_JOHN,
-        ]);
-
-        $user = User::find($authorId);
-
-        Post::query()
-            ->tap(new IsAuthorTap($user))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            sprintf("select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `post_author` = %d", $authorId)
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsAuthorTap::__invoke
-     */
     public function testDistinguishesBetweenDifferentAuthors(): void
     {
         $author1 = self::factory()->user->create([

--- a/tests/WordPress/Taps/Post/IsPingStatusTapTest.php
+++ b/tests/WordPress/Taps/Post/IsPingStatusTapTest.php
@@ -270,66 +270,6 @@ class IsPingStatusTapTest extends TestCase
      * @return void
      * @covers IsPingStatusTap::__invoke
      */
-    public function testGeneratesCorrectSqlQueryForOpenWithEnum(): void
-    {
-        Post::query()
-            ->tap(new IsPingStatusTap(PingStatus::Open))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `ping_status` = 'open'"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsPingStatusTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQueryForClosedWithEnum(): void
-    {
-        Post::query()
-            ->tap(new IsPingStatusTap(PingStatus::Closed))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `ping_status` = 'closed'"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsPingStatusTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQueryForOpenWithString(): void
-    {
-        Post::query()
-            ->tap(new IsPingStatusTap('open'))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `ping_status` = 'open'"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsPingStatusTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQueryForClosedWithString(): void
-    {
-        Post::query()
-            ->tap(new IsPingStatusTap('closed'))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `ping_status` = 'closed'"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsPingStatusTap::__invoke
-     */
     public function testStringAndEnumProduceSameResults(): void
     {
         self::factory()->post->create([

--- a/tests/WordPress/Taps/Post/IsPostTypeTapTest.php
+++ b/tests/WordPress/Taps/Post/IsPostTypeTapTest.php
@@ -176,21 +176,6 @@ class IsPostTypeTapTest extends TestCase
      * @return void
      * @covers IsPostTypeTap::__invoke
      */
-    public function testGeneratesCorrectSqlQuery(): void
-    {
-        Post::query()
-            ->tap(new IsPostTypeTap('product'))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `post_type` = 'product'"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsPostTypeTap::__invoke
-     */
     public function testDistinguishesBetweenDifferentPostTypes(): void
     {
         self::factory()->post->create([

--- a/tests/WordPress/Taps/Post/IsStatusTapTest.php
+++ b/tests/WordPress/Taps/Post/IsStatusTapTest.php
@@ -178,36 +178,6 @@ class IsStatusTapTest extends TestCase
      * @return void
      * @covers IsStatusTap::__invoke
      */
-    public function testGeneratesCorrectSqlQueryForPublishWithEnum(): void
-    {
-        Post::query()
-            ->tap(new IsStatusTap(PostStatus::Publish))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `post_status` = 'publish'"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsStatusTap::__invoke
-     */
-    public function testGeneratesCorrectSqlQueryForPublishWithString(): void
-    {
-        Post::query()
-            ->tap(new IsStatusTap('publish'))
-            ->get();
-
-        $this->assertLastQueryEquals(
-            "select `#TABLE_PREFIX#posts`.* from `#TABLE_PREFIX#posts` where `post_status` = 'publish'"
-        );
-    }
-
-    /**
-     * @return void
-     * @covers IsStatusTap::__invoke
-     */
     public function testDistinguishesBetweenDifferentStatuses(): void
     {
         self::factory()->post->create([

--- a/tests/WordPress/TestCase.php
+++ b/tests/WordPress/TestCase.php
@@ -91,18 +91,6 @@ abstract class TestCase extends \WP_UnitTestCase
     }
 
     /**
-     * @param string $query
-     * @param string $message
-     * @return void
-     */
-    public function assertLastQueryEquals(string $query, string $message = ''): void
-    {
-        global $wpdb;
-        $query = str_replace('#TABLE_PREFIX#', $wpdb->prefix, $query);
-        self::assertEquals($query, $wpdb->last_query, $message);
-    }
-
-    /**
      * Assert that the last executed SQL contains a substring.
      *
      * Use this only when the SQL shape is itself part of the contract

--- a/tests/WordPress/TestCase.php
+++ b/tests/WordPress/TestCase.php
@@ -91,63 +91,6 @@ abstract class TestCase extends \WP_UnitTestCase
     }
 
     /**
-     * @param string $table
-     * @param string $whereColumn
-     * @param string $whereValue
-     * @return void
-     */
-    protected function assertFindLastQuery(string $table, string $whereColumn, string $whereValue): void
-    {
-        $this->assertLastQueryEquals(
-            sprintf(
-                "select `#TABLE_PREFIX#%s`.* from `#TABLE_PREFIX#%s` where `%s` = '%s' limit 1",
-                $table,
-                $table,
-                $whereColumn,
-                $whereValue
-            )
-        );
-    }
-
-    /**
-     * @param string $table
-     * @param string $pkColumn
-     * @param string $pkValue
-     * @return void
-     */
-    public function assertLastQueryHasOneRelation(string $table, string $pkColumn, string $pkValue): void
-    {
-        $table = sprintf('#TABLE_PREFIX#%s', $table);
-        $this->assertLastQueryEquals(
-            sprintf(
-                "select `%1\$s`.* from `%1\$s` where `%1\$s`.`%2\$s` = %3\$s and `%1\$s`.`%2\$s` is not null limit 1",
-                $table,
-                $pkColumn,
-                $pkValue
-            )
-        );
-    }
-
-    /**
-     * @param string $table
-     * @param string $pkColumn
-     * @param string $pkValue
-     * @return void
-     */
-    public function assertLastQueryBelongsToRelation(string $table, string $pkColumn, string $pkValue): void
-    {
-        $table = sprintf('#TABLE_PREFIX#%s', $table);
-        $this->assertLastQueryEquals(
-            sprintf(
-                "select `%1\$s`.* from `%1\$s` where `%1\$s`.`%2\$s` = %3\$s limit 1",
-                $table,
-                $pkColumn,
-                $pkValue
-            )
-        );
-    }
-
-    /**
      * @param string $query
      * @param string $message
      * @return void

--- a/tests/WordPress/TestCase.php
+++ b/tests/WordPress/TestCase.php
@@ -160,6 +160,24 @@ abstract class TestCase extends \WP_UnitTestCase
     }
 
     /**
+     * Assert that the last executed SQL contains a substring.
+     *
+     * Use this only when the SQL shape is itself part of the contract
+     * (custom grammar, security regression tests). For most tests, prefer
+     * asserting on the result rows — see TESTS_AUDIT.md point #1.
+     *
+     * @param string $needle
+     * @param string $message
+     * @return void
+     */
+    public function assertLastQueryContains(string $needle, string $message = ''): void
+    {
+        global $wpdb;
+        $needle = str_replace('#TABLE_PREFIX#', $wpdb->prefix, $needle);
+        self::assertStringContainsString($needle, (string) $wpdb->last_query, $message);
+    }
+
+    /**
      * @param Collection $expectedItems
      * @param string $relationProperty
      * @param array $expectedIds

--- a/tests/stubs/wp-phpunit.php
+++ b/tests/stubs/wp-phpunit.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+/**
+ * Stub for static analysis only — wp-phpunit is loaded at runtime via the
+ * test bootstrap, not through Composer's autoloader, so PHPStan can't see
+ * the real class chain (WP_UnitTestCase → WP_UnitTestCase_Base →
+ * PHPUnit_Adapter_TestCase → Polyfill_TestCase). This minimal declaration
+ * is enough for PHPStan to resolve parent:: calls in test sub-classes.
+ *
+ * @see vendor/wp-phpunit/wp-phpunit/includes/abstract-testcase.php
+ */
+abstract class WP_UnitTestCase extends \PHPUnit\Framework\TestCase
+{
+}

--- a/tests/stubs/wp-phpunit.php
+++ b/tests/stubs/wp-phpunit.php
@@ -3,7 +3,6 @@
  * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
  * See LICENSE.txt for license details.
  */
-
 /**
  * Stub for static analysis only — wp-phpunit is loaded at runtime via the
  * test bootstrap, not through Composer's autoloader, so PHPStan can't see


### PR DESCRIPTION
- Move SAVEQUERIES to bootstrap and add assertLastQueryContains
- Drop redundant SQL-shape assertions (relations, finders, metas)
- Drop redundant SQL-shape assertions in Tap and CustomPost/CustomComment tests
- Drop assertLastQueryEquals; document SQL assertion policy
- Add CreatesCustomTable trait to drop test tables in tearDownAfterClass
- Add data providers and BuildsTestPost trait
- Add multisite test scaffolding (trait + smoke test + CI job
- Add @group annotations + CI fast-feedback gate and composer cache