### PR TITLE
🧪 Add and update database tests

### DIFF
--- a/tests/Unit/Concerns/HasMetasTest.php
+++ b/tests/Unit/Concerns/HasMetasTest.php
@@ -7,14 +7,52 @@
 namespace Dbout\WpOrm\Tests\Unit\Concerns;
 
 use Dbout\WpOrm\Concerns\HasMetas;
+use Dbout\WpOrm\Models\Meta\AbstractMeta;
+use Dbout\WpOrm\Models\Meta\PostMeta;
+use Dbout\WpOrm\Models\Meta\UserMeta;
 use Dbout\WpOrm\Models\Post;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 #[CoversTrait(HasMetas::class)]
 class HasMetasTest extends TestCase
 {
+    /**
+     * Pin: meta classes do not use SoftDeletes, so HasMetas::deleteMeta()
+     * calling forceDelete() is currently equivalent to delete().
+     *
+     * The use of forceDelete() in deleteMeta() is misleading because none of
+     * the meta classes use SoftDeletes. The call happens to be harmless TODAY,
+     * but if SoftDeletes is ever added to AbstractMeta, forceDelete() would
+     * silently bypass the soft-delete mechanism. This pin forces a
+     * re-evaluation of deleteMeta() in that case (it should switch to delete()).
+     *
+     * @param class-string<AbstractMeta> $metaClass
+     * @return void
+     */
+    #[Group('regression-pin')]
+    #[TestWith([PostMeta::class])]
+    #[TestWith([UserMeta::class])]
+    public function testMetaClassDoesNotUseSoftDeletes(string $metaClass): void
+    {
+        $traits = class_uses_recursive($metaClass);
+
+        $this->assertNotContains(
+            SoftDeletes::class,
+            $traits,
+            sprintf(
+                'Pin: %s does not use SoftDeletes today, so HasMetas::deleteMeta() '
+                . 'using forceDelete() is harmless. If you add SoftDeletes here, '
+                . 'switch deleteMeta() to delete().',
+                $metaClass
+            )
+        );
+    }
+
     /**
      * @return void
      */

--- a/tests/Unit/Orm/AbstractModelTest.php
+++ b/tests/Unit/Orm/AbstractModelTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\Unit\Orm;
+
+use Dbout\WpOrm\Orm\AbstractModel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AbstractModel::class)]
+#[CoversMethod(AbstractModel::class, '__call')]
+class AbstractModelTest extends TestCase
+{
+    /**
+     * Build a bare AbstractModel subclass without explicit accessors so the
+     * raw __call regex behavior is observable. Concrete models like Comment
+     * mask the bug by adding explicit *Attribute() accessors.
+     *
+     * @return AbstractModel
+     */
+    private function bareModel(): AbstractModel
+    {
+        return new class () extends AbstractModel {
+            protected $table = 'fake';
+            public $timestamps = false;
+        };
+    }
+
+    /**
+     * Pin: the snake_case conversion done in __call() splits acronyms
+     * letter-by-letter ("IP" → "_i_p", not "_ip").
+     *
+     * The regex `(?<!^)[A-Z]` inserts an underscore before EVERY uppercase
+     * letter, including the second letter of an acronym. The expected
+     * snake_case for getCommentAuthorIP would be `comment_author_ip`, but
+     * __call actually queries `comment_author_i_p`.
+     *
+     * If __call() is ever rewritten with a proper snake_case converter
+     * (e.g. Str::snake), this test will fail and signal that:
+     *   1. the bug is fixed
+     *   2. concrete models like Comment can drop their compensating accessors.
+     *
+     * @param string $methodName  Magic getter call.
+     * @param string $buggyKey    The (incorrect) snake_case key __call queries.
+     * @param string $correctKey  The snake_case key Str::snake() would produce.
+     * @return void
+     */
+    #[Group('regression-pin')]
+    #[TestWith(['getCommentAuthorIP',  'comment_author_i_p',  'comment_author_ip'])]
+    #[TestWith(['getCommentPostID',    'comment_post_i_d',    'comment_post_id'])]
+    public function testCallSplitsAcronymsLetterByLetter(
+        string $methodName,
+        string $buggyKey,
+        string $correctKey
+    ): void {
+        $model = $this->bareModel();
+
+        // Seed the buggy key — that is what __call currently looks up.
+        $model->setAttribute($buggyKey, 'value-on-buggy-key');
+        // Seed the correct key — proves __call does NOT use it today.
+        $model->setAttribute($correctKey, 'value-on-correct-key');
+
+        $this->assertSame(
+            'value-on-buggy-key',
+            $model->__call($methodName, []),
+            sprintf(
+                'Pin: __call queries `%s` instead of `%s`. If this fails, the snake_case '
+                . 'converter has been fixed — drop the compensating accessors in Comment.',
+                $buggyKey,
+                $correctKey
+            )
+        );
+    }
+
+    /**
+     * Pin: regular CamelCase (without acronyms) snake_cases correctly.
+     *
+     * Documents the cases where __call DOES work, so a future refactor can
+     * confirm it preserves these.
+     *
+     * @return void
+     */
+    #[Group('regression-pin')]
+    public function testCallHandlesRegularCamelCaseCorrectly(): void
+    {
+        $model = $this->bareModel();
+        $model->setAttribute('post_title', 'Hello world');
+
+        $this->assertSame('Hello world', $model->__call('getPostTitle', []));
+    }
+
+    /**
+     * Pin: setter form goes through the same snake_case conversion.
+     *
+     * @return void
+     */
+    #[Group('regression-pin')]
+    public function testSetCallAlsoSplitsAcronymsLetterByLetter(): void
+    {
+        $model = $this->bareModel();
+        $model->__call('setCommentAuthorIP', ['127.0.0.1']);
+
+        $this->assertSame('127.0.0.1', $model->getAttribute('comment_author_i_p'));
+        $this->assertNull($model->getAttribute('comment_author_ip'));
+    }
+}

--- a/tests/Unit/Orm/DatabaseTest.php
+++ b/tests/Unit/Orm/DatabaseTest.php
@@ -10,6 +10,7 @@ use Dbout\WpOrm\Exceptions\WpOrmException;
 use Dbout\WpOrm\Orm\Database;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
@@ -17,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversMethod(Database::class, 'getInstance')]
 #[CoversMethod(Database::class, 'isMaria')]
 #[CoversMethod(Database::class, 'getServerVersion')]
+#[CoversMethod(Database::class, 'pretend')]
+#[CoversMethod(Database::class, 'transaction')]
 class DatabaseTest extends TestCase
 {
     /**
@@ -107,6 +110,67 @@ class DatabaseTest extends TestCase
         $this->expectException(WpOrmException::class);
         $this->expectExceptionMessage('Unable to retrieve the server version.');
         $database->getServerVersion();
+    }
+
+    /**
+     * Pin: Database::pretend() always throws WpOrmException.
+     *
+     * The pretend() feature is not implemented in this connection. If support
+     * is ever added, this test will fail and signal that the contract changed.
+     *
+     * @return void
+     */
+    #[Group('regression-pin')]
+    public function testPretendAlwaysThrows(): void
+    {
+        $database = $this->createDatabaseWithMockedWpdb([]);
+
+        $this->expectException(WpOrmException::class);
+        $this->expectExceptionMessage('pretend feature not supported.');
+
+        $database->pretend(function (): void {
+            // never reached
+        });
+    }
+
+    /**
+     * Pin: Database::transaction() ignores the $attempts parameter.
+     *
+     * The $attempts parameter exists in the signature for compatibility with
+     * Connection::transaction() but no retry loop is implemented. If retry is
+     * ever added, this test will fail and signal that the contract changed.
+     *
+     * @return void
+     */
+    #[Group('regression-pin')]
+    public function testTransactionAttemptsParameterIsIgnored(): void
+    {
+        $database = $this->createDatabaseWithMockedWpdb([]);
+
+        $invocations = 0;
+        $exception = new \RuntimeException('boom');
+        $caught = null;
+
+        try {
+            $database->transaction(function () use (&$invocations, $exception): void {
+                $invocations++;
+                throw $exception;
+            }, 5);
+        } catch (\RuntimeException $e) {
+            $caught = $e;
+        }
+
+        $this->assertSame(
+            $exception,
+            $caught,
+            'transaction() must rethrow the inner exception.'
+        );
+        $this->assertSame(
+            1,
+            $invocations,
+            'transaction($attempts=5) currently invokes the callback exactly once; '
+            . 'update this pin if a retry loop is implemented.'
+        );
     }
 
     /**

--- a/tests/Unit/Orm/ResolverTest.php
+++ b/tests/Unit/Orm/ResolverTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\Unit\Orm;
+
+use Dbout\WpOrm\Orm\Database;
+use Dbout\WpOrm\Orm\Resolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Resolver::class)]
+class ResolverTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Provide a mocked $wpdb so Database::getInstance() can build a singleton.
+        $wpdb = $this->createStub(\wpdb::class);
+        $wpdb->prefix = 'wp_';
+        $wpdb->charset = 'utf8mb4';
+        $wpdb->collate = 'utf8mb4_unicode_ci';
+        $wpdb->method('db_version')->willReturn('8.0.0');
+
+        global $wpdb_global_backup;
+        $wpdb_global_backup = $GLOBALS['wpdb'] ?? null;
+        $GLOBALS['wpdb'] = $wpdb;
+
+        if (!defined('DB_NAME')) {
+            define('DB_NAME', 'test_db');
+        }
+
+        // Reset Database singleton between tests.
+        $reflection = new \ReflectionClass(Database::class);
+        $instance = $reflection->getProperty('instance');
+        $instance->setValue(null, null);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
+    {
+        global $wpdb_global_backup;
+        $GLOBALS['wpdb'] = $wpdb_global_backup;
+
+        parent::tearDown();
+    }
+
+    /**
+     * Pin: Resolver::connection() ignores its $name argument.
+     *
+     * Resolver always returns the Database singleton regardless of the
+     * requested connection name, so it is impossible to register multiple
+     * connections. If multi-connection support is ever added, this test will
+     * fail and signal the contract change.
+     *
+     * @return void
+     */
+    #[Group('regression-pin')]
+    public function testConnectionReturnsSameInstanceRegardlessOfName(): void
+    {
+        $resolver = new Resolver();
+
+        $default = $resolver->connection();
+        $named   = $resolver->connection('something_else');
+        $other   = $resolver->connection('yet_another');
+
+        $this->assertSame($default, $named);
+        $this->assertSame($default, $other);
+    }
+
+    /**
+     * Pin: Resolver::getDefaultConnection() returns '' when never set.
+     *
+     * @return void
+     */
+    #[Group('regression-pin')]
+    public function testGetDefaultConnectionReturnsEmptyStringWhenUnset(): void
+    {
+        $resolver = new Resolver();
+        $this->assertSame('', $resolver->getDefaultConnection());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetDefaultConnectionStoresName(): void
+    {
+        $resolver = new Resolver();
+        $resolver->setDefaultConnection('main');
+
+        $this->assertSame('main', $resolver->getDefaultConnection());
+    }
+}

--- a/tests/WordPress/Builders/CommentBuilderTest.php
+++ b/tests/WordPress/Builders/CommentBuilderTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Builders;
+
+use Dbout\WpOrm\Builders\CommentBuilder;
+use Dbout\WpOrm\Models\Comment;
+use Dbout\WpOrm\Tests\WordPress\TestCase;
+
+class CommentBuilderTest extends TestCase
+{
+    /**
+     * @return void
+     * @covers CommentBuilder::findAllByType
+     */
+    public function testFindAllByTypeReturnsOnlyMatchingType(): void
+    {
+        $reviewId = self::factory()->comment->create([
+            'comment_type'    => 'review',
+            'comment_content' => 'Review comment',
+        ]);
+
+        self::factory()->comment->create([
+            'comment_type'    => 'order_note',
+            'comment_content' => 'Order note',
+        ]);
+
+        $comments = Comment::query()->findAllByType('review');
+
+        /** @var Comment $first */
+        $first = $comments->first();
+
+        $this->assertCount(1, $comments->toArray());
+        $this->assertEquals($reviewId, $first->getId());
+        $this->assertEquals('review', $first->getCommentType());
+    }
+
+    /**
+     * @return void
+     * @covers CommentBuilder::findAllByType
+     */
+    public function testFindAllByTypeReturnsEmptyWhenNoMatch(): void
+    {
+        self::factory()->comment->create([
+            'comment_type'    => 'review',
+            'comment_content' => 'Review comment',
+        ]);
+
+        $comments = Comment::query()->findAllByType('unknown_type');
+
+        $this->assertCount(0, $comments->toArray());
+    }
+
+    /**
+     * @return void
+     * @covers CommentBuilder::whereTypes
+     */
+    public function testWhereTypesWithSingleType(): void
+    {
+        $reviewId = self::factory()->comment->create([
+            'comment_type'    => 'review',
+            'comment_content' => 'Review comment',
+        ]);
+
+        self::factory()->comment->create([
+            'comment_type'    => 'order_note',
+            'comment_content' => 'Order note',
+        ]);
+
+        $comments = Comment::query()
+            ->whereTypes('review')
+            ->get();
+
+        /** @var Comment $first */
+        $first = $comments->first();
+
+        $this->assertCount(1, $comments->toArray());
+        $this->assertEquals($reviewId, $first->getId());
+    }
+
+    /**
+     * @return void
+     * @covers CommentBuilder::whereTypes
+     */
+    public function testWhereTypesWithMultipleVariadicArgs(): void
+    {
+        $reviewId = self::factory()->comment->create([
+            'comment_type'    => 'review',
+            'comment_content' => 'Review comment',
+        ]);
+
+        $orderNoteId = self::factory()->comment->create([
+            'comment_type'    => 'order_note',
+            'comment_content' => 'Order note',
+        ]);
+
+        self::factory()->comment->create([
+            'comment_type'    => 'pingback',
+            'comment_content' => 'Pingback',
+        ]);
+
+        $comments = Comment::query()
+            ->whereTypes('review', 'order_note')
+            ->get();
+
+        $ids = $comments->pluck(Comment::COMMENT_ID)->toArray();
+
+        $this->assertCount(2, $comments->toArray());
+        $this->assertEqualsCanonicalizing([$reviewId, $orderNoteId], $ids);
+    }
+
+    /**
+     * @return void
+     * @covers CommentBuilder::whereTypes
+     */
+    public function testWhereTypesAcceptsArrayAsFirstArgument(): void
+    {
+        $reviewId = self::factory()->comment->create([
+            'comment_type'    => 'review',
+            'comment_content' => 'Review comment',
+        ]);
+
+        $orderNoteId = self::factory()->comment->create([
+            'comment_type'    => 'order_note',
+            'comment_content' => 'Order note',
+        ]);
+
+        self::factory()->comment->create([
+            'comment_type'    => 'pingback',
+            'comment_content' => 'Pingback',
+        ]);
+
+        $comments = Comment::query()
+            ->whereTypes(['review', 'order_note'])
+            ->get();
+
+        $ids = $comments->pluck(Comment::COMMENT_ID)->toArray();
+
+        $this->assertCount(2, $comments->toArray());
+        $this->assertEqualsCanonicalizing([$reviewId, $orderNoteId], $ids);
+    }
+
+    /**
+     * @return void
+     * @covers CommentBuilder::whereTypes
+     */
+    public function testWhereTypesCanBeChained(): void
+    {
+        $postId      = self::factory()->post->create();
+        $otherPostId = self::factory()->post->create();
+
+        $expectedId = self::factory()->comment->create([
+            'comment_type'    => 'review',
+            'comment_post_ID' => $postId,
+            'comment_content' => 'Review on target post',
+        ]);
+
+        self::factory()->comment->create([
+            'comment_type'    => 'review',
+            'comment_post_ID' => $otherPostId,
+            'comment_content' => 'Review on other post',
+        ]);
+
+        self::factory()->comment->create([
+            'comment_type'    => 'order_note',
+            'comment_post_ID' => $postId,
+            'comment_content' => 'Order note on target post',
+        ]);
+
+        $comments = Comment::query()
+            ->whereTypes('review')
+            ->where(Comment::POST_ID, $postId)
+            ->get();
+
+        /** @var Comment $first */
+        $first = $comments->first();
+
+        $this->assertCount(1, $comments->toArray());
+        $this->assertEquals($expectedId, $first->getId());
+    }
+}

--- a/tests/WordPress/Builders/OptionBuilderTest.php
+++ b/tests/WordPress/Builders/OptionBuilderTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Builders;
+
+use Dbout\WpOrm\Builders\OptionBuilder;
+use Dbout\WpOrm\Models\Option;
+use Dbout\WpOrm\Tests\WordPress\TestCase;
+
+class OptionBuilderTest extends TestCase
+{
+    /**
+     * @return void
+     * @covers OptionBuilder::whereName
+     */
+    public function testWhereNameReturnsMatchingOption(): void
+    {
+        add_option('wp_orm_test_option', 'expected_value');
+        add_option('wp_orm_other_option', 'other_value');
+
+        /** @var Option|null $option */
+        $option = Option::query()
+            ->whereName('wp_orm_test_option')
+            ->first();
+
+        $this->assertNotNull($option);
+        $this->assertEquals('wp_orm_test_option', $option->getOptionName());
+        $this->assertEquals('expected_value', $option->getOptionValue());
+    }
+
+    /**
+     * @return void
+     * @covers OptionBuilder::whereName
+     */
+    public function testWhereNameReturnsNullWhenNoMatch(): void
+    {
+        add_option('wp_orm_test_option', 'expected_value');
+
+        $option = Option::query()
+            ->whereName('wp_orm_unknown_option')
+            ->first();
+
+        $this->assertNull($option);
+    }
+
+    /**
+     * @return void
+     * @covers OptionBuilder::whereName
+     */
+    public function testWhereNameReturnsExactlyOneRow(): void
+    {
+        add_option('wp_orm_test_option', 'expected_value');
+        add_option('wp_orm_test_option_2', 'other_value');
+
+        $options = Option::query()
+            ->whereName('wp_orm_test_option')
+            ->get();
+
+        $this->assertCount(1, $options->toArray());
+    }
+
+    /**
+     * @return void
+     * @covers OptionBuilder::whereName
+     */
+    public function testWhereNameCanBeChained(): void
+    {
+        add_option('wp_orm_test_option', 'expected_value');
+
+        $count = Option::query()
+            ->whereName('wp_orm_test_option')
+            ->where(Option::VALUE, 'expected_value')
+            ->count();
+
+        $this->assertEquals(1, $count);
+    }
+}

--- a/tests/WordPress/Builders/TermBuilderTest.php
+++ b/tests/WordPress/Builders/TermBuilderTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Builders;
+
+use Dbout\WpOrm\Builders\TermBuilder;
+use Dbout\WpOrm\Models\Term;
+use Dbout\WpOrm\Tests\WordPress\TestCase;
+
+class TermBuilderTest extends TestCase
+{
+    /**
+     * @return void
+     * @covers TermBuilder::findAllByTaxonomy
+     */
+    public function testFindAllByTaxonomyReturnsOnlyMatchingTerms(): void
+    {
+        $categoryTermId = self::factory()->term->create([
+            'taxonomy' => 'category',
+            'name'     => 'My category',
+        ]);
+
+        self::factory()->term->create([
+            'taxonomy' => 'post_tag',
+            'name'     => 'My tag',
+        ]);
+
+        $terms = Term::query()->findAllByTaxonomy('category');
+
+        $ids = $terms->pluck(Term::TERM_ID)->toArray();
+
+        $this->assertContains($categoryTermId, $ids);
+        $this->assertCount(1, array_intersect([$categoryTermId], $ids));
+
+        /** @var Term $first */
+        $first = $terms->firstWhere(Term::TERM_ID, $categoryTermId);
+        $this->assertNotNull($first);
+        $this->assertEquals('My category', $first->getName());
+    }
+
+    /**
+     * @return void
+     * @covers TermBuilder::findAllByTaxonomy
+     */
+    public function testFindAllByTaxonomyReturnsEmptyWhenNoMatch(): void
+    {
+        self::factory()->term->create([
+            'taxonomy' => 'category',
+            'name'     => 'My category',
+        ]);
+
+        $terms = Term::query()->findAllByTaxonomy('unknown_taxonomy');
+
+        $this->assertCount(0, $terms->toArray());
+    }
+
+    /**
+     * @return void
+     * @covers TermBuilder::findAllByTaxonomy
+     */
+    public function testFindAllByTaxonomyReturnsMultipleTerms(): void
+    {
+        $tagId1 = self::factory()->term->create([
+            'taxonomy' => 'post_tag',
+            'name'     => 'First tag',
+        ]);
+
+        $tagId2 = self::factory()->term->create([
+            'taxonomy' => 'post_tag',
+            'name'     => 'Second tag',
+        ]);
+
+        self::factory()->term->create([
+            'taxonomy' => 'category',
+            'name'     => 'A category',
+        ]);
+
+        $terms = Term::query()->findAllByTaxonomy('post_tag');
+
+        $ids = $terms->pluck(Term::TERM_ID)->toArray();
+
+        $this->assertContains($tagId1, $ids);
+        $this->assertContains($tagId2, $ids);
+        $this->assertCount(2, array_intersect([$tagId1, $tagId2], $ids));
+    }
+}

--- a/tests/WordPress/Orm/DatabaseTransactionTest.php
+++ b/tests/WordPress/Orm/DatabaseTransactionTest.php
@@ -166,6 +166,73 @@ class DatabaseTransactionTest extends TestCase
     }
 
     /**
+     * Pin: nested transactions are not isolated by SAVEPOINTs.
+     *
+     * Database::beginTransaction() always emits `START TRANSACTION;` regardless
+     * of nesting depth, and rollBack() always emits `ROLLBACK;`. There is no
+     * SAVEPOINT logic, so:
+     *
+     *   - calling beginTransaction() while another transaction is open implicitly
+     *     commits the outer one (MySQL behavior on START TRANSACTION),
+     *   - calling rollBack() inside an "inner" transaction rolls back ALL the
+     *     outstanding work, not just the inner statements.
+     *
+     * The transactionLevel() counter increments correctly, which makes it look
+     * like nested transactions work — but the underlying isolation is fake.
+     *
+     * If real SAVEPOINT support is ever added, this test will fail and signal
+     * that nested rollback semantics have changed.
+     *
+     * @group regression-pin
+     * @throws \Throwable
+     * @return void
+     * @covers Database::beginTransaction
+     * @covers Database::rollBack
+     */
+    public function testNestedTransactionRollbackIsNotIsolatedBySavepoint(): void
+    {
+        $insert = sprintf('INSERT INTO %s (name, url) VALUES(?, ?);', $this->tableName);
+
+        // Outer transaction: insert "outer".
+        $this->db->beginTransaction();
+        $this->db->insert($insert, ['outer', 'outer-url']);
+        $this->assertSame(1, $this->db->transactionLevel());
+
+        // "Inner" transaction: emits another START TRANSACTION which implicitly
+        // commits the outer work in MySQL — no SAVEPOINT is created.
+        $this->db->beginTransaction();
+        $this->db->insert($insert, ['inner', 'inner-url']);
+        $this->assertSame(2, $this->db->transactionLevel());
+
+        // Roll back the inner level. With true SAVEPOINTs only "inner" would
+        // disappear; today this ROLLBACK targets whichever transaction MySQL
+        // currently has open, leaving "outer" already committed by the implicit
+        // commit above.
+        $this->db->rollBack();
+        $this->assertSame(1, $this->db->transactionLevel());
+
+        // Roll back the "outer" level — but "outer" was already committed by
+        // the implicit commit, so this ROLLBACK is a no-op for the row.
+        $this->db->rollBack();
+        $this->assertSame(0, $this->db->transactionLevel());
+
+        $names = $this->model::query()->pluck('name')->toArray();
+
+        $this->assertContains(
+            'outer',
+            $names,
+            'Pin: outer row persists because the inner beginTransaction() implicitly '
+            . 'committed it (no SAVEPOINT). If true nested transactions are added, '
+            . 'this row should have been rolled back.'
+        );
+        $this->assertNotContains(
+            'inner',
+            $names,
+            'Inner row was rolled back by the inner ROLLBACK, as expected.'
+        );
+    }
+
+    /**
      * @param string $mode
      * @return void
      */

--- a/tests/WordPress/Support/BuildsTestPost.php
+++ b/tests/WordPress/Support/BuildsTestPost.php
@@ -11,8 +11,6 @@ use Dbout\WpOrm\Models\Post;
 /**
  * Test fixture helpers to reduce the new-Post-set-title-set-name-set-type-save
  * boilerplate that recurs across builder, meta and concern tests.
- *
- * @see TESTS_AUDIT.md point #5 (data providers + BuildsTestPost trait)
  */
 trait BuildsTestPost
 {

--- a/tests/WordPress/Support/CreatesCustomTable.php
+++ b/tests/WordPress/Support/CreatesCustomTable.php
@@ -14,8 +14,7 @@ use Illuminate\Database\Schema\Blueprint;
  *
  * Tables registered via createCustomTable() are dropped automatically in
  * tearDownAfterClass(). This avoids the leak that occurs when tests call
- * dbDelta() or Schema::create() without ever cleaning up afterwards
- * (cf. TESTS_AUDIT.md point #3).
+ * dbDelta() or Schema::create() without ever cleaning up afterwards.
  *
  * Usage:
  *

--- a/tests/WordPress/Taps/Option/IsAutoloadTapTest.php
+++ b/tests/WordPress/Taps/Option/IsAutoloadTapTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Copyright © Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpOrm\Tests\WordPress\Taps\Option;
+
+use Dbout\WpOrm\Enums\YesNo;
+use Dbout\WpOrm\Models\Option;
+use Dbout\WpOrm\Taps\Option\IsAutoloadTap;
+use Dbout\WpOrm\Tests\WordPress\TestCase;
+
+class IsAutoloadTapTest extends TestCase
+{
+    /**
+     * Prefix used to isolate the test fixtures from the options
+     * already loaded by the WordPress bootstrap (siteurl, blogname, …).
+     */
+    private const string PREFIX = 'wp_orm_autoload_test_';
+
+    /**
+     * @param string $name
+     * @param string $autoload
+     * @return Option
+     */
+    private function createOption(string $name, string $autoload): Option
+    {
+        $option = new Option();
+        $option->setOptionName(self::PREFIX . $name);
+        $option->setOptionValue('value');
+        $option->setAutoload($autoload);
+        $option->save();
+
+        return $option;
+    }
+
+    /**
+     * @return void
+     * @covers IsAutoloadTap::__construct
+     * @covers IsAutoloadTap::__invoke
+     */
+    public function testFiltersAutoloadedOptionsWithBoolTrue(): void
+    {
+        $autoloaded = $this->createOption('one', 'yes');
+        $this->createOption('two', 'no');
+
+        $options = Option::query()
+            ->tap(new IsAutoloadTap(true))
+            ->where(Option::NAME, 'LIKE', self::PREFIX . '%')
+            ->get();
+
+        $names = $options->pluck(Option::NAME)->toArray();
+
+        $this->assertCount(1, $options->toArray());
+        $this->assertEquals([$autoloaded->getOptionName()], $names);
+    }
+
+    /**
+     * @return void
+     * @covers IsAutoloadTap::__invoke
+     */
+    public function testFiltersNonAutoloadedOptionsWithBoolFalse(): void
+    {
+        $this->createOption('one', 'yes');
+        $manual = $this->createOption('two', 'no');
+
+        $options = Option::query()
+            ->tap(new IsAutoloadTap(false))
+            ->where(Option::NAME, 'LIKE', self::PREFIX . '%')
+            ->get();
+
+        $names = $options->pluck(Option::NAME)->toArray();
+
+        $this->assertCount(1, $options->toArray());
+        $this->assertEquals([$manual->getOptionName()], $names);
+    }
+
+    /**
+     * @return void
+     * @covers IsAutoloadTap::__construct
+     */
+    public function testDefaultsToAutoloadedWhenNoParameterProvided(): void
+    {
+        $autoloaded = $this->createOption('one', 'yes');
+        $this->createOption('two', 'no');
+
+        $options = Option::query()
+            ->tap(new IsAutoloadTap())
+            ->where(Option::NAME, 'LIKE', self::PREFIX . '%')
+            ->get();
+
+        $names = $options->pluck(Option::NAME)->toArray();
+
+        $this->assertCount(1, $options->toArray());
+        $this->assertEquals([$autoloaded->getOptionName()], $names);
+    }
+
+    /**
+     * @return void
+     * @covers IsAutoloadTap::__invoke
+     */
+    public function testAcceptsYesNoEnumYes(): void
+    {
+        $autoloaded = $this->createOption('one', 'yes');
+        $this->createOption('two', 'no');
+
+        $options = Option::query()
+            ->tap(new IsAutoloadTap(YesNo::Yes))
+            ->where(Option::NAME, 'LIKE', self::PREFIX . '%')
+            ->get();
+
+        $names = $options->pluck(Option::NAME)->toArray();
+
+        $this->assertCount(1, $options->toArray());
+        $this->assertEquals([$autoloaded->getOptionName()], $names);
+    }
+
+    /**
+     * @return void
+     * @covers IsAutoloadTap::__invoke
+     */
+    public function testAcceptsYesNoEnumNo(): void
+    {
+        $this->createOption('one', 'yes');
+        $manual = $this->createOption('two', 'no');
+
+        $options = Option::query()
+            ->tap(new IsAutoloadTap(YesNo::No))
+            ->where(Option::NAME, 'LIKE', self::PREFIX . '%')
+            ->get();
+
+        $names = $options->pluck(Option::NAME)->toArray();
+
+        $this->assertCount(1, $options->toArray());
+        $this->assertEquals([$manual->getOptionName()], $names);
+    }
+
+    /**
+     * @return void
+     * @covers IsAutoloadTap::__invoke
+     */
+    public function testReturnsEmptyWhenNoOptionsMatch(): void
+    {
+        $this->createOption('one', 'yes');
+
+        $options = Option::query()
+            ->tap(new IsAutoloadTap(false))
+            ->where(Option::NAME, 'LIKE', self::PREFIX . '%')
+            ->get();
+
+        $this->assertCount(0, $options->toArray());
+    }
+
+    /**
+     * @return void
+     * @covers IsAutoloadTap::__invoke
+     */
+    public function testCanBeChainedWithWhereName(): void
+    {
+        $expected = $this->createOption('expected', 'yes');
+        $this->createOption('other', 'yes');
+        $this->createOption('expected_2', 'no');
+
+        /** @var Option|null $option */
+        $option = Option::query()
+            ->tap(new IsAutoloadTap(true))
+            ->whereName(self::PREFIX . 'expected')
+            ->first();
+
+        $this->assertNotNull($option);
+        $this->assertEquals($expected->getId(), $option->getId());
+    }
+}

--- a/tests/WordPress/TestCase.php
+++ b/tests/WordPress/TestCase.php
@@ -95,7 +95,7 @@ abstract class TestCase extends \WP_UnitTestCase
      *
      * Use this only when the SQL shape is itself part of the contract
      * (custom grammar, security regression tests). For most tests, prefer
-     * asserting on the result rows — see TESTS_AUDIT.md point #1.
+     * asserting on the result rows.
      *
      * @param string $needle
      * @param string $message


### PR DESCRIPTION
- Add coverage for `CommentBuilder`, `TermBuilder`, `OptionBuilder` & `IsAutoloadTap`
- Add and update database tests